### PR TITLE
Added auto pr from upstream workflow

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,16 @@
+name: Upstream to PR
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  autoupdate:
+    uses: neuro-inc/reuse/.github/workflows/auto-pr.yaml@master
+    with:
+      upstream_repository: https://github.com/BorisPolonsky/dify-helm
+      upstream_tag_regex: 'dify-\d+\..*'
+    secrets:
+      personal_access_token: ${{ secrets.AUTO_PR_PAT }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation of pull requests for upstream changes. The workflow is scheduled to run daily at noon and can also be triggered manually.

Key changes:

* Added a new workflow configuration file `.github/workflows/auto-pr.yml` to automate the creation of pull requests for upstream changes using the `neuro-inc/reuse` action.