### PR TITLE
Upstream tag dify-0.22.0 (revision 5a67aff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm install my-release dify/dify
 - [x] qdrant
 - [x] milvus
 - [x] pgvector
-
+- [x] Tencent Vector DB
 ## Contributors
 <a href="https://github.com/borispolonsky/dify-helm/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=borispolonsky/dify-helm" />

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ helm install my-release dify/dify
 ## Supported Component 
 ### Components that could be deployed on kubernetes in current version
 - [x] core (`api`, `worker`, `sandbox`)
+- [x] ssrf_proxy
 - [x] proxy (via built-in `nginx` or `ingress`)
 - [x] redis
 - [x] postgresql

--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.21.0
+version: 0.22.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.16"
+appVersion: "0.14.2"
 
 dependencies:
 - name: postgresql

--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.20.1
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.3"
+appVersion: "0.6.16"
 
 dependencies:
 - name: postgresql

--- a/charts/dify/templates/_helpers.tpl
+++ b/charts/dify/templates/_helpers.tpl
@@ -113,12 +113,67 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Create the name of the service account to use
+Create the name of the service account to use for the Dify API
 */}}
-{{- define "dify.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "dify.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
+{{- define "dify.api.serviceAccountName" -}}
+{{- if .Values.api.serviceAccount.create -}}
+    {{ default (include "dify.api.fullname" .) .Values.api.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.api.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the Proxy
+*/}}
+{{- define "dify.proxy.serviceAccountName" -}}
+{{- if .Values.proxy.serviceAccount.create -}}
+    {{ default (include "dify.nginx.fullname" .) .Values.proxy.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.proxy.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the Sandbox
+*/}}
+{{- define "dify.sandbox.serviceAccountName" -}}
+{{- if .Values.sandbox.serviceAccount.create -}}
+    {{ default (include "dify.sandbox.fullname" .) .Values.sandbox.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.sandbox.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the ssrfProxy
+*/}}
+{{- define "dify.ssrfProxy.serviceAccountName" -}}
+{{- if .Values.ssrfProxy.serviceAccount.create -}}
+    {{ default (include "dify.ssrfProxy.fullname" .) .Values.ssrfProxy.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.ssrfProxy.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the Web
+*/}}
+{{- define "dify.web.serviceAccountName" -}}
+{{- if .Values.web.serviceAccount.create -}}
+    {{ default (include "dify.web.fullname" .) .Values.web.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.web.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the Dify Worker
+*/}}
+{{- define "dify.worker.serviceAccountName" -}}
+{{- if .Values.worker.serviceAccount.create -}}
+    {{ default (include "dify.worker.fullname" .) .Values.worker.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.worker.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -37,9 +37,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
-      {{- if .Values.api.serviceAccountName}}
-      serviceAccountName: {{ .Values.api.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "dify.api.serviceAccountName" . }}
       {{- if eq .Release.Name "dify"}}
       {{/*
       Disable service environment variables,

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.api.enabled}}
-{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled) -}}
+{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.api.enabled}}
-{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled) -}}
+{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled .Values.externalCOS.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      {{- if .Values.api.serviceAccountName}}
+      serviceAccountName: {{ .Values.api.serviceAccountName }}
+      {{- end }}
       {{- if eq .Release.Name "dify"}}
       {{/*
       Disable service environment variables,

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -57,6 +57,29 @@ spec:
       - image: "{{ .Values.image.api.repository }}:{{ .Values.image.api.tag }}"
         imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"
         name: api
+        {{- if .Values.api.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.api.customLivenessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.api.livenessProbe.enabled }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.api.livenessProbe "enabled") "context" $) | nindent 10 }}
+          httpGet:
+            path: /health
+            port: api
+        {{- end }}
+        {{- if .Values.api.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.api.customReadinessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.api.readinessProbe.enabled }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.api.readinessProbe "enabled") "context" $) | nindent 10 }}
+          httpGet:
+            path: /health
+            port: api
+        {{- end }}
+        {{- if .Values.api.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.api.customStartupProbe "context" $) | nindent 10 }}
+        {{- else if .Values.api.startupProbe.enabled }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.api.startupProbe "enabled") "context" $) | nindent 10 }}
+          tcpSocket:
+            port: api
+        {{- end }}
         env:
         {{- if .Values.sandbox.enabled }}
         - name: CODE_EXECUTION_API_KEY

--- a/charts/dify/templates/api-service-account.yaml
+++ b/charts/dify/templates/api-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.api.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.api.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: api
+  {{- if or .Values.api.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.api.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.api.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -273,16 +273,6 @@ MILVUS_PORT: {{ .Values.externalMilvus.port | toString | quote }}
 # MILVUS_PASSWORD: {{ .Values.externalMilvus.password | quote }}
 # The milvus tls switch.
 MILVUS_SECURE: {{ .Values.externalMilvus.useTLS | toString | quote }}
-{{- else if .Values.externalTvector.enabled}}
-# tencent vector configurations, only available when VECTOR_STORE is `tencent`
-VECTOR_STORE: tencent 
-TENCENT_VECTOR_DB_URL: {{ .Values.externalTencent.url }}
-TENCENT_VECTOR_DB_API_KEY: {{ .Values.externalTencent.apiKey }}
-TENCENT_VECTOR_DB_TIMEOUT: {{ .Values.externalTencent.timeout | quote }}
-TENCENT_VECTOR_DB_USERNAME: {{ .Values.externalTencent.username }}
-TENCENT_VECTOR_DB_DATABASE: {{ .Values.externalTencent.database }}
-TENCENT_VECTOR_DB_SHARD: {{ .Values.externalTencent.shard | quote }}
-TENCENT_VECTOR_DB_REPLICAS: {{ .Values.externalTencent.replicas | quote }}
 {{- else if .Values.externalPgvector.enabled}}
 # pgvector configurations, only available when VECTOR_STORE is `pgvecto-rs or pgvector`
 VECTOR_STORE: pgvector
@@ -291,6 +281,16 @@ PGVECTOR_PORT: {{ .Values.externalPgvector.port | toString | quote }}
 PGVECTOR_DATABASE: {{ .Values.externalPgvector.dbName }}
 # DB_USERNAME: {{ .Values.externalPgvector.username }}
 # DB_PASSWORD: {{ .Values.externalPgvector.password }}
+{{- else if .Values.externalTencentVectorDB.enabled}}
+# tencent vector configurations, only available when VECTOR_STORE is `tencent`
+VECTOR_STORE: tencent
+TENCENT_VECTOR_DB_URL: {{ .Values.externalTencentVectorDB.url | quote }}
+TENCENT_VECTOR_DB_API_KEY: {{ .Values.externalTencentVectorDB.apiKey | quote }}
+TENCENT_VECTOR_DB_TIMEOUT: {{ .Values.externalTencentVectorDB.timeout | quote }}
+TENCENT_VECTOR_DB_USERNAME: {{ .Values.externalTencentVectorDB.username | quote }}
+TENCENT_VECTOR_DB_DATABASE: {{ .Values.externalTencentVectorDB.database | quote }}
+TENCENT_VECTOR_DB_SHARD: {{ .Values.externalTencentVectorDB.shard | quote }}
+TENCENT_VECTOR_DB_REPLICAS: {{ .Values.externalTencentVectorDB.replicas | quote }}
 {{- else if .Values.weaviate.enabled }}
 # The type of vector store to use. Supported values are `weaviate`, `qdrant`, `milvus`.
 VECTOR_STORE: weaviate

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -178,6 +178,19 @@ ALIYUN_OSS_AUTH_VERSION: {{ .Values.externalOSS.authVersion }}
 STORAGE_TYPE: google-storage
 GOOGLE_STORAGE_BUCKET_NAME: {{ .Values.externalGCS.bucketName }}
 GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64: {{ .Values.externalGCS.serviceAccountJsonBase64 }}
+{{- else if .Values.externalCOS.enabled }}
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss`, `google-storage` and `tencent-cos`, Default: `local`
+STORAGE_TYPE: tencent-cos
+# The name of the Tencent COS bucket to use for storing files.
+TENCENT_COS_BUCKET_NAME: {{ .Values.externalCOS.bucketName }}
+# The secret key to use for authenticating with the Tencent COS service.
+TENCENT_COS_SECRET_KEY: {{ .Values.externalCOS.secretKey }}
+# The secret id to use for authenticating with the Tencent COS service.
+TENCENT_COS_SECRET_ID: {{ .Values.externalCOS.secretId }}
+# The region of the Tencent COS service.
+TENCENT_COS_REGION: {{ .Values.externalCOS.region }}
+# The scheme of the Tencent COS service.
+TENCENT_COS_SCHEME: {{ .Values.externalCOS.scheme }}
 {{- else }}
 # The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob`, Default: `local`
 STORAGE_TYPE: local
@@ -260,6 +273,16 @@ MILVUS_PORT: {{ .Values.externalMilvus.port | toString | quote }}
 # MILVUS_PASSWORD: {{ .Values.externalMilvus.password | quote }}
 # The milvus tls switch.
 MILVUS_SECURE: {{ .Values.externalMilvus.useTLS | toString | quote }}
+{{- else if .Values.externalTvector.enabled}}
+# tencent vector configurations, only available when VECTOR_STORE is `tencent`
+VECTOR_STORE: tencent 
+TENCENT_VECTOR_DB_URL: {{ .Values.externalTencent.url }}
+TENCENT_VECTOR_DB_API_KEY: {{ .Values.externalTencent.apiKey }}
+TENCENT_VECTOR_DB_TIMEOUT: {{ .Values.externalTencent.timeout | quote }}
+TENCENT_VECTOR_DB_USERNAME: {{ .Values.externalTencent.username }}
+TENCENT_VECTOR_DB_DATABASE: {{ .Values.externalTencent.database }}
+TENCENT_VECTOR_DB_SHARD: {{ .Values.externalTencent.shard | quote }}
+TENCENT_VECTOR_DB_REPLICAS: {{ .Values.externalTencent.replicas | quote }}
 {{- else if .Values.externalPgvector.enabled}}
 # pgvector configurations, only available when VECTOR_STORE is `pgvecto-rs or pgvector`
 VECTOR_STORE: pgvector

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -147,7 +147,7 @@ DB_DATABASE: {{ .Values.postgresql.global.postgresql.auth.database }}
 
 {{- define "dify.storage.config" -}}
 {{- if .Values.externalS3.enabled }}
-# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss` and `google-storage`, Default: `local`
 STORAGE_TYPE: s3
 # The S3 storage configurations, only available when STORAGE_TYPE is `s3`.
 S3_ENDPOINT: {{ .Values.externalS3.endpoint }}
@@ -156,7 +156,7 @@ S3_BUCKET_NAME: {{ .Values.externalS3.bucketName }}
 # S3_SECRET_KEY: {{ .Values.externalS3.secretKey }}
 S3_REGION: {{ .Values.externalS3.region }}
 {{- else if .Values.externalAzureBlobStorage.enabled }}
-# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss` and `google-storage`, Default: `local`
 STORAGE_TYPE: azure-blob
 # The Azure Blob storage configurations, only available when STORAGE_TYPE is `azure-blob`.
 AZURE_BLOB_ACCOUNT_NAME: {{ .Values.externalAzureBlobStorage.account | quote }}
@@ -164,7 +164,7 @@ AZURE_BLOB_ACCOUNT_NAME: {{ .Values.externalAzureBlobStorage.account | quote }}
 AZURE_BLOB_CONTAINER_NAME: {{ .Values.externalAzureBlobStorage.container | quote }}
 AZURE_BLOB_ACCOUNT_URL: {{ .Values.externalAzureBlobStorage.url | quote }}
 {{- else if .Values.externalOSS.enabled }}
-# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss` and `google-storage`, Default: `local`
 STORAGE_TYPE: aliyun-oss
 # The OSS storage configurations, only available when STORAGE_TYPE is `aliyun-oss`.
 ALIYUN_OSS_ENDPOINT: {{ .Values.externalOSS.endpoint }}
@@ -174,7 +174,7 @@ ALIYUN_OSS_BUCKET_NAME: {{ .Values.externalOSS.bucketName }}
 ALIYUN_OSS_REGION: {{ .Values.externalOSS.region }}
 ALIYUN_OSS_AUTH_VERSION: {{ .Values.externalOSS.authVersion }}
 {{- else if .Values.externalGCS.enabled }}
-# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss` and `google-storage`, Default: `local`
 STORAGE_TYPE: google-storage
 GOOGLE_STORAGE_BUCKET_NAME: {{ .Values.externalGCS.bucketName }}
 GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64: {{ .Values.externalGCS.serviceAccountJsonBase64 }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -154,7 +154,7 @@ S3_ENDPOINT: {{ .Values.externalS3.endpoint }}
 S3_BUCKET_NAME: {{ .Values.externalS3.bucketName }}
 # S3_ACCESS_KEY: {{ .Values.externalS3.accessKey }}
 # S3_SECRET_KEY: {{ .Values.externalS3.secretKey }}
-S3_REGION: 'us-east-1'
+S3_REGION: {{ .Values.externalS3.region }}
 {{- else if .Values.externalAzureBlobStorage.enabled }}
 # The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob` and `aliyun-oss`, Default: `local`
 STORAGE_TYPE: azure-blob

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -147,7 +147,7 @@ DB_DATABASE: {{ .Values.postgresql.global.postgresql.auth.database }}
 
 {{- define "dify.storage.config" -}}
 {{- if .Values.externalS3.enabled }}
-# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob` and `aliyun-oss`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
 STORAGE_TYPE: s3
 # The S3 storage configurations, only available when STORAGE_TYPE is `s3`.
 S3_ENDPOINT: {{ .Values.externalS3.endpoint }}
@@ -156,7 +156,7 @@ S3_BUCKET_NAME: {{ .Values.externalS3.bucketName }}
 # S3_SECRET_KEY: {{ .Values.externalS3.secretKey }}
 S3_REGION: {{ .Values.externalS3.region }}
 {{- else if .Values.externalAzureBlobStorage.enabled }}
-# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob` and `aliyun-oss`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
 STORAGE_TYPE: azure-blob
 # The Azure Blob storage configurations, only available when STORAGE_TYPE is `azure-blob`.
 AZURE_BLOB_ACCOUNT_NAME: {{ .Values.externalAzureBlobStorage.account | quote }}
@@ -164,7 +164,7 @@ AZURE_BLOB_ACCOUNT_NAME: {{ .Values.externalAzureBlobStorage.account | quote }}
 AZURE_BLOB_CONTAINER_NAME: {{ .Values.externalAzureBlobStorage.container | quote }}
 AZURE_BLOB_ACCOUNT_URL: {{ .Values.externalAzureBlobStorage.url | quote }}
 {{- else if .Values.externalOSS.enabled }}
-# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob` and `aliyun-oss`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
 STORAGE_TYPE: aliyun-oss
 # The OSS storage configurations, only available when STORAGE_TYPE is `aliyun-oss`.
 ALIYUN_OSS_ENDPOINT: {{ .Values.externalOSS.endpoint }}
@@ -173,6 +173,11 @@ ALIYUN_OSS_BUCKET_NAME: {{ .Values.externalOSS.bucketName }}
 # ALIYUN_OSS_SECRET_KEY: {{ .Values.externalOSS.secretKey }}
 ALIYUN_OSS_REGION: {{ .Values.externalOSS.region }}
 ALIYUN_OSS_AUTH_VERSION: {{ .Values.externalOSS.authVersion }}
+{{- else if .Values.externalGCS.enabled }}
+# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
+STORAGE_TYPE: google-storage
+GOOGLE_STORAGE_BUCKET_NAME: {{ .Values.externalGCS.bucketName }}
+GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64: {{ .Values.externalGCS.serviceAccountJsonBase64 }}
 {{- else }}
 # The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob`, Default: `local`
 STORAGE_TYPE: local

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -355,7 +355,7 @@ http {
     keepalive_timeout  65;
 
     #gzip  on;
-    client_max_body_size 15M;
+    client_max_body_size {{ .Values.proxy.clientMaxBodySize | default "15m" }};
 
     include /etc/nginx/conf.d/*.conf;
 }

--- a/charts/dify/templates/proxy-deployment.yaml
+++ b/charts/dify/templates/proxy-deployment.yaml
@@ -36,9 +36,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
-      {{- if .Values.proxy.serviceAccountName}}
-      serviceAccountName: {{ .Values.proxy.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "dify.proxy.serviceAccountName" . }}
       {{- if .Values.image.proxy.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.proxy.pullSecrets }}

--- a/charts/dify/templates/proxy-deployment.yaml
+++ b/charts/dify/templates/proxy-deployment.yaml
@@ -49,6 +49,15 @@ spec:
       - image: "{{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}"
         imagePullPolicy: "{{ .Values.image.proxy.pullPolicy }}"
         name: nginx
+        {{- if .Values.proxy.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customLivenessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.proxy.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customReadinessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.proxy.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customStartupProbe "context" $) | nindent 10 }}
+        {{- end }}
         env:
         {{- if .Values.proxy.extraEnv }}
           {{- toYaml .Values.proxy.extraEnv | nindent 8 }}

--- a/charts/dify/templates/proxy-deployment.yaml
+++ b/charts/dify/templates/proxy-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      {{- if .Values.proxy.serviceAccountName}}
+      serviceAccountName: {{ .Values.proxy.serviceAccountName }}
+      {{- end }}
       {{- if .Values.image.proxy.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.proxy.pullSecrets }}

--- a/charts/dify/templates/proxy-service-account.yaml
+++ b/charts/dify/templates/proxy-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.proxy.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.proxy.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: proxy
+  {{- if or .Values.proxy.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.proxy.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -36,9 +36,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
-      {{- if .Values.sandbox.serviceAccountName}}
-      serviceAccountName: {{ .Values.sandbox.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "dify.sandbox.serviceAccountName" . }}
       {{- if .Values.image.sandbox.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.sandbox.pullSecrets }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -49,6 +49,27 @@ spec:
       - image: "{{ .Values.image.sandbox.repository }}:{{ .Values.image.sandbox.tag }}"
         imagePullPolicy: "{{ .Values.image.sandbox.pullPolicy }}"
         name: sandbox
+        {{- if .Values.sandbox.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.customLivenessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.sandbox.livenessProbe.enabled }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.sandbox.livenessProbe "enabled") "context" $) | nindent 10 }}
+          tcpSocket:
+            port: sandbox
+        {{- end }}
+        {{- if .Values.sandbox.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.customReadinessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.sandbox.readinessProbe.enabled }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.sandbox.readinessProbe "enabled") "context" $) | nindent 10 }}
+          tcpSocket:
+            port: sandbox
+        {{- end }}
+        {{- if .Values.sandbox.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.customStartupProbe "context" $) | nindent 10 }}
+        {{- else if .Values.sandbox.startupProbe.enabled }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.sandbox.startupProbe "enabled") "context" $) | nindent 10 }}
+          tcpSocket:
+            port: sandbox
+        {{- end }}
         env:
         {{- if .Values.sandbox.extraEnv }}
           {{- toYaml .Values.sandbox.extraEnv | nindent 8 }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      {{- if .Values.sandbox.serviceAccountName}}
+      serviceAccountName: {{ .Values.sandbox.serviceAccountName }}
+      {{- end }}
       {{- if .Values.image.sandbox.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.sandbox.pullSecrets }}

--- a/charts/dify/templates/sandbox-service-account.yaml
+++ b/charts/dify/templates/sandbox-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.sandbox.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.sandbox.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: sandbox
+  {{- if or .Values.sandbox.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.sandbox.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.sandbox.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -36,6 +36,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "dify.ssrfProxy.serviceAccountName" . }}
       {{- if .Values.image.ssrfProxy.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.ssrfProxy.pullSecrets }}

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -46,6 +46,15 @@ spec:
       - image: "{{ .Values.image.ssrfProxy.repository }}:{{ .Values.image.ssrfProxy.tag }}"
         imagePullPolicy: "{{ .Values.image.ssrfProxy.pullPolicy }}"
         name: squid
+        {{- if .Values.ssrfProxy.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.customLivenessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.ssrfProxy.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.customReadinessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.ssrfProxy.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.customStartupProbe "context" $) | nindent 10 }}
+        {{- end }}
         env:
         {{- if .Values.ssrfProxy.extraEnv }}
           {{- toYaml .Values.ssrfProxy.extraEnv | nindent 8 }}

--- a/charts/dify/templates/ssrf-proxy-service-account.yaml
+++ b/charts/dify/templates/ssrf-proxy-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.ssrfProxy.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.ssrfProxy.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: ssrfProxy
+  {{- if or .Values.ssrfProxy.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ssrfProxy.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.ssrfProxy.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/templates/validations/_tplvalues.tpl
+++ b/charts/dify/templates/validations/_tplvalues.tpl
@@ -1,0 +1,52 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template perhaps with scope if the scope is present.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Merge a list of values that contains template after rendering them.
+Merge precedence is consistent with http://masterminds.github.io/sprig/dicts.html#merge-mustmerge
+Usage:
+{{ include "common.tplvalues.merge" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+*/}}
+{{- define "common.tplvalues.merge" -}}
+{{- $dst := dict -}}
+{{- range .values -}}
+{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | merge $dst -}}
+{{- end -}}
+{{ $dst | toYaml }}
+{{- end -}}
+
+{{/*
+Merge a list of values that contains template after rendering them.
+Merge precedence is consistent with https://masterminds.github.io/sprig/dicts.html#mergeoverwrite-mustmergeoverwrite
+Usage:
+{{ include "common.tplvalues.merge-overwrite" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+*/}}
+{{- define "common.tplvalues.merge-overwrite" -}}
+{{- $dst := dict -}}
+{{- range .values -}}
+{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | mergeOverwrite $dst -}}
+{{- end -}}
+{{ $dst | toYaml }}
+{{- end -}}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -36,9 +36,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
-      {{- if .Values.web.serviceAccountName}}
-      serviceAccountName: {{ .Values.web.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "dify.web.serviceAccountName" . }}
       {{- if .Values.image.web.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.web.pullSecrets }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      {{- if .Values.web.serviceAccountName}}
+      serviceAccountName: {{ .Values.web.serviceAccountName }}
+      {{- end }}
       {{- if .Values.image.web.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.web.pullSecrets }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.livenessProbe "enabled") "context" $) | nindent 10 }}
           httpGet:
             path: /apps
-            port: http
+            port: web
             httpHeaders:
             - name: accept-language
               value: en
@@ -66,7 +66,7 @@ spec:
         readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.readinessProbe "enabled") "context" $) | nindent 10 }}
           httpGet:
             path: /apps
-            port: http
+            port: web
             httpHeaders:
             - name: accept-language
               value: en

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -49,6 +49,35 @@ spec:
       - image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag }}"
         imagePullPolicy: "{{ .Values.image.web.pullPolicy }}"
         name: web
+        {{- if .Values.web.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.web.customLivenessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.web.livenessProbe.enabled }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.livenessProbe "enabled") "context" $) | nindent 10 }}
+          httpGet:
+            path: /apps
+            port: http
+            httpHeaders:
+            - name: accept-language
+              value: en
+        {{- end }}
+        {{- if .Values.web.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.web.customReadinessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.web.readinessProbe.enabled }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.readinessProbe "enabled") "context" $) | nindent 10 }}
+          httpGet:
+            path: /apps
+            port: http
+            httpHeaders:
+            - name: accept-language
+              value: en
+        {{- end }}
+        {{- if .Values.web.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.web.customStartupProbe "context" $) | nindent 10 }}
+        {{- else if .Values.web.startupProbe.enabled }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.startupProbe "enabled") "context" $) | nindent 10 }}
+          tcpSocket:
+            port: web
+        {{- end }}
         env:
         {{- if .Values.web.extraEnv }}
           {{- toYaml .Values.web.extraEnv | nindent 8 }}

--- a/charts/dify/templates/web-service-account.yaml
+++ b/charts/dify/templates/web-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.web.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.web.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: web
+  {{- if or .Values.web.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.web.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.web.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -37,9 +37,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
-      {{- if .Values.worker.serviceAccountName}}
-      serviceAccountName: {{ .Values.worker.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "dify.worker.serviceAccountName" . }}
       {{- if .Values.image.api.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.api.pullSecrets }}

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.worker.enabled}}
-{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled) -}}
+{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.worker.enabled}}
-{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled) -}}
+{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled .Values.externalCOS.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -50,6 +50,15 @@ spec:
       - image: "{{ .Values.image.api.repository }}:{{ .Values.image.api.tag }}"
         imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"
         name: worker
+        {{- if .Values.worker.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customLivenessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.worker.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customReadinessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.worker.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customStartupProbe "context" $) | nindent 10 }}
+        {{- end }}
         env:
         {{- if .Values.worker.extraEnv }}
           {{- toYaml .Values.worker.extraEnv | nindent 8 }}

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      {{- if .Values.worker.serviceAccountName}}
+      serviceAccountName: {{ .Values.worker.serviceAccountName }}
+      {{- end }}
       {{- if .Values.image.api.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.api.pullSecrets }}

--- a/charts/dify/templates/worker-service-account.yaml
+++ b/charts/dify/templates/worker-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.worker.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.worker.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: worker
+  {{- if or .Values.worker.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.worker.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.worker.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -194,7 +194,22 @@ api:
       accessModes: ReadWriteMany
       size: 5Gi
       subPath: ""
-
+  ## Dify API ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param api.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param api.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param api.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param api.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
 worker:
   enabled: true
@@ -225,6 +240,22 @@ worker:
   #        name: my-secret
   #        key: DB_PASSWORD
   logLevel: INFO
+  ## Dify Worker ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param worker.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param worker.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param worker.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param worker.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
 proxy:
   enabled: true
@@ -274,6 +305,22 @@ proxy:
     annotations: {}
     labels: {}
     clusterIP: ""
+  ## Proxy ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param proxy.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param proxy.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param proxy.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param proxy.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
 web:
   enabled: true
@@ -323,6 +370,22 @@ web:
     annotations: {}
     labels: {}
     clusterIP: ""
+  ## Web ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param web.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param web.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param web.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param web.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
 sandbox:
   enabled: true
@@ -378,6 +441,22 @@ sandbox:
     apiKey: "dify-sandbox"
   privileged:
     false
+  ## Sandbox ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param sandbox.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param sandbox.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param sandbox.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param sandbox.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
 ssrfProxy:
   enabled: false
@@ -425,6 +504,22 @@ ssrfProxy:
     annotations: {}
     labels: {}
     clusterIP: ""
+  ## ssrfProxy ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param ssrfProxy.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param ssrfProxy.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param ssrfProxy.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param ssrfProxy.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: { }
 
 postgresql:
   enabled: true

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -5,7 +5,7 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "0.6.16"
+    tag: "0.14.2"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -15,7 +15,7 @@ image:
     #   - myRegistryKeySecretName
   web:    
     repository: langgenius/dify-web
-    tag: "0.6.16"
+    tag: "0.14.2"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -25,7 +25,7 @@ image:
     #   - myRegistryKeySecretName
   sandbox:
     repository: langgenius/dify-sandbox
-    tag: "0.2.1"
+    tag: "0.2.10"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -2966,13 +2966,13 @@ externalPgvector:
   dbName: dify
 
 ###################################
-# External Tencent
-# - these configs take effect only if both `externalWeaviate.enabled`, `externalQdrant.enabled` and `externalMilvus.enabled` and `externalPgvector.enabled` are set as `false` and `externalTvector.enabled` is `true`
+# External Tencent Vector DB
+# - these configs take effect only if both `externalWeaviate.enabled`, `externalQdrant.enabled` and `externalMilvus.enabled` and `externalPgvector.enabled` are set as `false` and `externalTencentVectorDB.enabled` is `true`
 ###################################
-externalTvector:
+externalTencentVectorDB:
   enabled: false
   url: "your-tencent-vector-db-url"
-  apiKey: "your-tencent-vector-api-key"
+  apiKey: "your-tencent-vector-db-api-key"
   timeout: 30
   username: "root"
   database: "dify"

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -2801,6 +2801,18 @@ externalGCS:
   serviceAccountJsonBase64: ""
 
 ###################################
+# External TENCENT COS
+# - these configs are only used when `externalS3.enabled` and `externalAzureBlobStorage.enabled` and `externalOSS.enabled`  and `externalGCS.enabled` are false and `externalCOS.enabled` is true
+###################################
+externalCOS:
+  enabled: false
+  secretKey: "your-secret-key"
+  secretId: "your-secret-id"
+  region: "your-region"
+  bucketName: "your-bucket-name"
+  scheme: "your-scheme"
+
+###################################
 # External Redis
 # - these configs are only used when `externalRedis.enabled` is true
 ###################################
@@ -2857,3 +2869,17 @@ externalPgvector:
   address: "pgvector"
   port: 5432
   dbName: dify
+
+###################################
+# External Tencent
+# - these configs take effect only if both `externalWeaviate.enabled`, `externalQdrant.enabled` and `externalMilvus.enabled` and `externalPgvector.enabled` are set as `false` and `externalTvector.enabled` is `true`
+###################################
+externalTvector:
+  enabled: false
+  url: "your-tencent-vector-db-url"
+  apiKey: "your-tencent-vector-api-key"
+  timeout: 30
+  username: "root"
+  database: "dify"
+  shard: 1
+  replicas: 2

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -62,6 +62,38 @@ api:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for api containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param api.livenessProbe.enabled Enable livenessProbe on api nodes
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param api.readinessProbe.enabled Enable readinessProbe on api nodes
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param api.startupProbe.enabled Enable startupProbe on api containers
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param api.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param api.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param api.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary.
   # Variable defined here takes higher priority than those from `ConfigMap` generated given `.Values`
@@ -171,6 +203,14 @@ worker:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for worker containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param worker.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param worker.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param worker.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary.
   # Variable defined here takes higher priority than those from `ConfigMap` generated given `.Values`
@@ -193,6 +233,14 @@ proxy:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for proxy containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param proxy.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param proxy.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param proxy.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   # - name: LANG
@@ -232,6 +280,38 @@ web:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for web containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param web.livenessProbe.enabled Enable livenessProbe on web nodes
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param web.readinessProbe.enabled Enable readinessProbe on web nodes
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param web.startupProbe.enabled Enable startupProbe on web containers
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param web.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param web.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param web.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   - name: EDITION
@@ -249,6 +329,38 @@ sandbox:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for sandbox containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param sandbox.livenessProbe.enabled Enable livenessProbe on sandbox nodes
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 2
+    successThreshold: 1
+  ## @param sandbox.readinessProbe.enabled Enable readinessProbe on sandbox nodes
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 2
+    successThreshold: 1
+  ## @param sandbox.startupProbe.enabled Enable startupProbe on sandbox containers
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 2
+    successThreshold: 1
+  ## @param sandbox.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param sandbox.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param sandbox.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   # - name: LANG
@@ -272,6 +384,14 @@ ssrfProxy:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for ssrf proxy containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param ssrfProxy.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param ssrfProxy.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param ssrfProxy.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   # - name: LANG

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -241,6 +241,8 @@ proxy:
   customReadinessProbe: {}
   ## @param proxy.customStartupProbe Custom startupProbe that overrides the default one
   customStartupProbe: {}
+  ## @param proxy.clientMaxBodySize Custom client_max_body_size param nginx default: 15m
+  clientMaxBodySize: ""
   extraEnv:
   # Apply your own Environment Variables if necessary
   # - name: LANG

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -2765,6 +2765,7 @@ externalS3:
   rootPath: ""
   useIAM: false
   iamEndpoint: ""
+  region: "us-east-1"
 
 ###################################
 # External Azure Blob Storage

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -2792,6 +2792,15 @@ externalOSS:
   authVersion: v4
 
 ###################################
+# External Google Cloud Storage
+# - these configs are only used when `externalS3.enabled` and `externalAzureBlobStorage.enabled` and `externalOSS.enabled` are false and `externalGCS.enabled` is true
+###################################
+externalGCS:
+  enabled: false
+  bucketName: "difyai"
+  serviceAccountJsonBase64: ""
+
+###################################
 # External Redis
 # - these configs are only used when `externalRedis.enabled` is true
 ###################################

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -5,7 +5,7 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "0.6.11"
+    tag: "0.6.16"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -15,7 +15,7 @@ image:
     #   - myRegistryKeySecretName
   web:    
     repository: langgenius/dify-web
-    tag: "0.6.11"
+    tag: "0.6.16"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Integrating latest changes from [BorisPolonsky/dify-helm](https://github.com/BorisPolonsky/dify-helm) tag dify-0.22.0

5a67aff25c9b9c24396a98d26378472e6277405a Update app version to `0.14.2` and bump chart version to `0.22.0` (BorisPolonsky/dify-helm#109)
48108739525b7f02df589ca14891f6a6caf2bf6e Update README.md (BorisPolonsky/dify-helm#108)
2df3710e6fdeaaa3920c05e8c5e26e01822e0124 Patch Tencent Vector DB Confiuration (BorisPolonsky/dify-helm#106)
ca5aa52febe692f0d9b0a888560c54a47379fe0b feat: add service account for each services (BorisPolonsky/dify-helm#99)
4fc4e08823f23b2cb2bcf2f9076dc90d537bfb82 add Tencent-vectorDB and tencent-cos (BorisPolonsky/dify-helm#104)
0d534465fa28418dea6ef01ec7d21a3427feeacf Patch comments of external storages introduced in `4544ebd788f6a0c56c968b9854552a43c3e42277` (BorisPolonsky/dify-helm#103)
4544ebd788f6a0c56c968b9854552a43c3e42277 feat: add external google cloud storage config (BorisPolonsky/dify-helm#100)
0e59632ed48e74d147ab32c092b7e31d0ec30b0e Move default value of `S3_REGION` to `.Values.externalS3.region` (BorisPolonsky/dify-helm#102)
fdccbfc1ebcb4d4ad169ab2b2a0f7f63dc6293ad Add a flexible set of clientMaxBodySize limits (BorisPolonsky/dify-helm#97)
0117f962ca125156b0e4b4d39dfb6e9b7abd5b2f Fix default definition of `readinesProbe` and `livenessProbe` (BorisPolonsky/dify-helm#96)
6e44ca4d03fb2fe984b6e580b3c1c669c6fcae8a `livenessProbe`, `readinessProbe` and `startupProbe` support (BorisPolonsky/dify-helm#94)
199785cd6678a6dd03a8e8dd8d15d73c7af52142 add service account to deployments (BorisPolonsky/dify-helm#92)
6ae42f34836a641b1ee34ad591143a709227e8d7 Update to 0.21.0 (BorisPolonsky/dify-helm#87)