### PR TITLE
Upstream tag dify-0.23.0-rc3 (revision 8540a1b)

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=false
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -24,12 +24,6 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
 
-      - name: Add Helm repositories
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add weaviate https://weaviate.github.io/weaviate-helm
-          helm repo update
-
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
@@ -40,12 +34,4 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=false
-
-      - name: Create kind cluster
-        if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.12.0
-
-      - name: Run chart-testing (install)
-        if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --config ct.yaml

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
 
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add weaviate https://weaviate.github.io/weaviate-helm
+          helm repo update
+
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,45 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.12.0
+
+      - uses: actions/setup-python@v5.3.0
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.12.0
+
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Update dependency
         run: find charts -mindepth 1 -maxdepth 1 -type d | xargs -I{} helm dependency update {}
+
+      - name: Add repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add weaviate https://weaviate.github.io/weaviate-helm
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,8 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Update dependency
-        run: find charts -mindepth 1 -maxdepth 1 -type d | xargs -I{} echo helm dependency update {}
     
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-    
+      - name: Update dependency
+        run: find charts -mindepth 1 -maxdepth 1 -type d | xargs -I{} helm dependency update {}
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         env:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm install my-release dify/dify
 - [x] qdrant
 - [x] milvus
 - [x] pgvector
-
+- [x] Tencent Vector DB
 ## Contributors
 <a href="https://github.com/borispolonsky/dify-helm/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=borispolonsky/dify-helm" />

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ helm install my-release dify/dify
 ## Supported Component 
 ### Components that could be deployed on kubernetes in current version
 - [x] core (`api`, `worker`, `sandbox`)
+- [x] ssrf_proxy
 - [x] proxy (via built-in `nginx` or `ingress`)
 - [x] redis
 - [x] postgresql

--- a/charts/dify/Chart.lock
+++ b/charts/dify/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.5.6
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.13.2
+- name: weaviate
+  repository: https://weaviate.github.io/weaviate-helm
+  version: 16.1.0
+digest: sha256:efe04fe8ac9fe3e5a5e7a7f0252f296305004a87d8832b80e4e37aaedc5878a4
+generated: "2023-06-16T17:43:21.971658921+08:00"

--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.22.0
+version: 0.23.0-rc1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.2"
+appVersion: "1.0.0"
 
 dependencies:
 - name: postgresql

--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.23.0-rc2
+version: 0.23.0-rc3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.23.0-rc1
+version: 0.23.0-rc2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.21.0
+version: 0.22.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.16"
+appVersion: "0.14.2"
 
 dependencies:
 - name: postgresql

--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.20.1
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.3"
+appVersion: "0.6.16"
 
 dependencies:
 - name: postgresql

--- a/charts/dify/templates/_helpers.tpl
+++ b/charts/dify/templates/_helpers.tpl
@@ -113,12 +113,67 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Create the name of the service account to use
+Create the name of the service account to use for the Dify API
 */}}
-{{- define "dify.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "dify.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
+{{- define "dify.api.serviceAccountName" -}}
+{{- if .Values.api.serviceAccount.create -}}
+    {{ default (include "dify.api.fullname" .) .Values.api.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.api.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the Proxy
+*/}}
+{{- define "dify.proxy.serviceAccountName" -}}
+{{- if .Values.proxy.serviceAccount.create -}}
+    {{ default (include "dify.nginx.fullname" .) .Values.proxy.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.proxy.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the Sandbox
+*/}}
+{{- define "dify.sandbox.serviceAccountName" -}}
+{{- if .Values.sandbox.serviceAccount.create -}}
+    {{ default (include "dify.sandbox.fullname" .) .Values.sandbox.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.sandbox.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the ssrfProxy
+*/}}
+{{- define "dify.ssrfProxy.serviceAccountName" -}}
+{{- if .Values.ssrfProxy.serviceAccount.create -}}
+    {{ default (include "dify.ssrfProxy.fullname" .) .Values.ssrfProxy.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.ssrfProxy.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the Web
+*/}}
+{{- define "dify.web.serviceAccountName" -}}
+{{- if .Values.web.serviceAccount.create -}}
+    {{ default (include "dify.web.fullname" .) .Values.web.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.web.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the Dify Worker
+*/}}
+{{- define "dify.worker.serviceAccountName" -}}
+{{- if .Values.worker.serviceAccount.create -}}
+    {{ default (include "dify.worker.fullname" .) .Values.worker.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.worker.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/dify/templates/_helpers.tpl
+++ b/charts/dify/templates/_helpers.tpl
@@ -72,6 +72,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a default fully qualified plugin-daemon name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "dify.pluginDaemon.fullname" -}}
+{{ template "dify.fullname" . }}-plugin-daemon
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "dify.chart" -}}
@@ -175,5 +183,16 @@ Create the name of the service account to use for the Dify Worker
     {{ default (include "dify.worker.fullname" .) .Values.worker.serviceAccount.name | trunc 63 | trimSuffix "-" }}
 {{- else -}}
     {{ default "default" .Values.worker.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the Dify Plugin Daemon
+*/}}
+{{- define "dify.pluginDaemon.serviceAccountName" -}}
+{{- if .Values.pluginDaemon.serviceAccount.create -}}
+    {{ default (include "dify.pluginDaemon.fullname" .) .Values.pluginDaemon.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.pluginDaemon.serviceAccount.name }}
 {{- end -}}
 {{- end -}}

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -37,9 +37,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
-      {{- if .Values.api.serviceAccountName}}
-      serviceAccountName: {{ .Values.api.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "dify.api.serviceAccountName" . }}
       {{- if eq .Release.Name "dify"}}
       {{/*
       Disable service environment variables,

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.api.enabled}}
-{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled) -}}
+{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -51,6 +51,10 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.api.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.api.podSecurityContext | indent 8 }}
+      {{- end }}
       containers:
       - image: "{{ .Values.image.api.repository }}:{{ default .Chart.AppVersion .Values.image.api.tag }}"
         imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"
@@ -77,6 +81,10 @@ spec:
         startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.api.startupProbe "enabled") "context" $) | nindent 10 }}
           tcpSocket:
             port: api
+        {{- end }}
+        {{- if .Values.api.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.api.containerSecurityContext | indent 10 }}
         {{- end }}
         env:
         {{- if .Values.sandbox.enabled }}

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -52,7 +52,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-      - image: "{{ .Values.image.api.repository }}:{{ .Values.image.api.tag }}"
+      - image: "{{ .Values.image.api.repository }}:{{ default .Chart.AppVersion .Values.image.api.tag }}"
         imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"
         name: api
         {{- if .Values.api.customLivenessProbe }}

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.api.enabled}}
-{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled) -}}
+{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled .Values.externalCOS.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -26,6 +26,8 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/api-config: {{ include (print $.Template.BasePath "/api-config.yaml") . | sha256sum }}
+        checksum/api-secret: {{ include (print $.Template.BasePath "/api-secret.yaml") . | sha256sum }}
 {{ include "dify.ud.annotations" . | indent 8 }}
       labels:
 {{- include "dify.selectorLabels" . | nindent 8 }}

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      {{- if .Values.api.serviceAccountName}}
+      serviceAccountName: {{ .Values.api.serviceAccountName }}
+      {{- end }}
       {{- if eq .Release.Name "dify"}}
       {{/*
       Disable service environment variables,

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -57,6 +57,29 @@ spec:
       - image: "{{ .Values.image.api.repository }}:{{ .Values.image.api.tag }}"
         imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"
         name: api
+        {{- if .Values.api.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.api.customLivenessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.api.livenessProbe.enabled }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.api.livenessProbe "enabled") "context" $) | nindent 10 }}
+          httpGet:
+            path: /health
+            port: api
+        {{- end }}
+        {{- if .Values.api.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.api.customReadinessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.api.readinessProbe.enabled }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.api.readinessProbe "enabled") "context" $) | nindent 10 }}
+          httpGet:
+            path: /health
+            port: api
+        {{- end }}
+        {{- if .Values.api.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.api.customStartupProbe "context" $) | nindent 10 }}
+        {{- else if .Values.api.startupProbe.enabled }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.api.startupProbe "enabled") "context" $) | nindent 10 }}
+          tcpSocket:
+            port: api
+        {{- end }}
         env:
         {{- if .Values.sandbox.enabled }}
         - name: CODE_EXECUTION_API_KEY

--- a/charts/dify/templates/api-service-account.yaml
+++ b/charts/dify/templates/api-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.api.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.api.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: api
+  {{- if or .Values.api.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.api.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.api.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -273,16 +273,6 @@ MILVUS_PORT: {{ .Values.externalMilvus.port | toString | quote }}
 # MILVUS_PASSWORD: {{ .Values.externalMilvus.password | quote }}
 # The milvus tls switch.
 MILVUS_SECURE: {{ .Values.externalMilvus.useTLS | toString | quote }}
-{{- else if .Values.externalTvector.enabled}}
-# tencent vector configurations, only available when VECTOR_STORE is `tencent`
-VECTOR_STORE: tencent 
-TENCENT_VECTOR_DB_URL: {{ .Values.externalTencent.url }}
-TENCENT_VECTOR_DB_API_KEY: {{ .Values.externalTencent.apiKey }}
-TENCENT_VECTOR_DB_TIMEOUT: {{ .Values.externalTencent.timeout | quote }}
-TENCENT_VECTOR_DB_USERNAME: {{ .Values.externalTencent.username }}
-TENCENT_VECTOR_DB_DATABASE: {{ .Values.externalTencent.database }}
-TENCENT_VECTOR_DB_SHARD: {{ .Values.externalTencent.shard | quote }}
-TENCENT_VECTOR_DB_REPLICAS: {{ .Values.externalTencent.replicas | quote }}
 {{- else if .Values.externalPgvector.enabled}}
 # pgvector configurations, only available when VECTOR_STORE is `pgvecto-rs or pgvector`
 VECTOR_STORE: pgvector
@@ -291,6 +281,16 @@ PGVECTOR_PORT: {{ .Values.externalPgvector.port | toString | quote }}
 PGVECTOR_DATABASE: {{ .Values.externalPgvector.dbName }}
 # DB_USERNAME: {{ .Values.externalPgvector.username }}
 # DB_PASSWORD: {{ .Values.externalPgvector.password }}
+{{- else if .Values.externalTencentVectorDB.enabled}}
+# tencent vector configurations, only available when VECTOR_STORE is `tencent`
+VECTOR_STORE: tencent
+TENCENT_VECTOR_DB_URL: {{ .Values.externalTencentVectorDB.url | quote }}
+TENCENT_VECTOR_DB_API_KEY: {{ .Values.externalTencentVectorDB.apiKey | quote }}
+TENCENT_VECTOR_DB_TIMEOUT: {{ .Values.externalTencentVectorDB.timeout | quote }}
+TENCENT_VECTOR_DB_USERNAME: {{ .Values.externalTencentVectorDB.username | quote }}
+TENCENT_VECTOR_DB_DATABASE: {{ .Values.externalTencentVectorDB.database | quote }}
+TENCENT_VECTOR_DB_SHARD: {{ .Values.externalTencentVectorDB.shard | quote }}
+TENCENT_VECTOR_DB_REPLICAS: {{ .Values.externalTencentVectorDB.replicas | quote }}
 {{- else if .Values.weaviate.enabled }}
 # The type of vector store to use. Supported values are `weaviate`, `qdrant`, `milvus`.
 VECTOR_STORE: weaviate

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -74,7 +74,7 @@ SSRF_PROXY_HTTPS_URL: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Value
 {{- end }}
 
 {{- if .Values.pluginDaemon.enabled }}
-PLUGIN_DAEMON_URL: http://{{ template "dify.pluginDaemon.fullname" .}}:{{ .Values.pluginDaemon.service.port }}
+PLUGIN_DAEMON_URL: http://{{ template "dify.pluginDaemon.fullname" .}}:{{ .Values.pluginDaemon.service.ports.daemon }}
 {{- end }}
 {{- end }}
 
@@ -109,7 +109,7 @@ LOG_LEVEL: {{ .Values.worker.logLevel | quote }}
 {{ include "dify.vectordb.config" . }}
 {{ include "dify.mail.config" . }}
 {{- if .Values.pluginDaemon.enabled }}
-PLUGIN_DAEMON_URL: http://{{ template "dify.pluginDaemon.fullname" .}}:{{ .Values.pluginDaemon.service.port }}
+PLUGIN_DAEMON_URL: http://{{ template "dify.pluginDaemon.fullname" .}}:{{ .Values.pluginDaemon.service.ports.daemon }}
 {{- end }}
 {{- end }}
 
@@ -430,7 +430,7 @@ server {
     }
 
     location /e {
-      proxy_pass http://{{ template "dify.pluginDaemon.fullname" .}}:{{ .Values.pluginDaemon.service.port }};
+      proxy_pass http://{{ template "dify.pluginDaemon.fullname" .}}:{{ .Values.pluginDaemon.service.ports.daemon }};
       include proxy.conf;
     }
 
@@ -507,6 +507,9 @@ cache_store_log none
 DB_DATABASE: {{ .Values.pluginDaemon.database | quote }}
 {{- end }}
 SERVER_PORT: "5002"
+PLUGIN_REMOTE_INSTALLING_HOST: "0.0.0.0"
+PLUGIN_REMOTE_INSTALLING_PORT: "5003"
 MAX_PLUGIN_PACKAGE_SIZE: "52428800"
 PLUGIN_WORKING_PATH: {{ .Values.pluginDaemon.persistence.mountPath | quote }}
+DIFY_INNER_API_URL: http://{{ template "dify.api.fullname" .}}:{{ .Values.api.service.port }}
 {{- end }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -274,6 +274,8 @@ VECTOR_STORE: milvus
 MILVUS_HOST: {{ .Values.externalMilvus.host | quote }}
 # The milvus host.
 MILVUS_PORT: {{ .Values.externalMilvus.port | toString | quote }}
+# The milvus database
+MILVUS_DATABASE: {{ .Values.externalMilvus.database | quote }}
 # The milvus username.
 # MILVUS_USER: {{ .Values.externalMilvus.user | quote }}
 # The milvus password.

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -131,7 +131,7 @@ APP_API_URL: {{ .Values.api.url.appApi | quote }}
 # DB_PASSWORD: {{ .Values.externalPostgres.password }}
 DB_HOST: {{ .Values.externalPostgres.address }}
 DB_PORT: {{ .Values.externalPostgres.port | toString | quote }}
-DB_DATABASE: {{ .Values.externalPostgres.dbName }}
+DB_DATABASE: {{ .Values.externalPostgres.database.api | quote }}
 {{- else if .Values.postgresql.enabled }}
   {{ with .Values.postgresql.global.postgresql.auth }}
   {{- if empty .username }}
@@ -509,12 +509,21 @@ cache_store_log none
 {{- end }}
 {{- end }}
 
+{{- define "dify.pluginDaemon.db.config" -}}
+{{- if .Values.externalPostgres.enabled }}
+DB_HOST: {{ .Values.externalPostgres.address }}
+DB_PORT: {{ .Values.externalPostgres.port | toString | quote }}
+DB_DATABASE: {{ .Values.externalPostgres.database.pluginDaemon | quote }}
+{{- else if .Values.postgresql.enabled }}
+# N.B.: `pluginDaemon` will the very same `PostgresSQL` database as `api`, `worker`,
+# which is NOT recommended for production and subject to possible confliction in the future releases of `dify`
+{{- include "dify.db.config" . }}
+{{- end }}
+{{- end }}
+
 {{- define "dify.pluginDaemon.config" }}
 {{- include "dify.redis.config" . }}
-{{- include "dify.db.config" .}}
-{{- if .Values.pluginDaemon.database }}
-DB_DATABASE: {{ .Values.pluginDaemon.database | quote }}
-{{- end }}
+{{- include "dify.pluginDaemon.db.config" .}}
 SERVER_PORT: "5002"
 PLUGIN_REMOTE_INSTALLING_HOST: "0.0.0.0"
 PLUGIN_REMOTE_INSTALLING_PORT: "5003"

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -434,6 +434,15 @@ server {
       include proxy.conf;
     }
 
+    location /marketplace {
+      rewrite ^/marketplace/(.*)$ /$1 break;
+      proxy_ssl_server_name on;
+      proxy_pass https://marketplace.dify.ai;
+      proxy_pass_request_headers off;
+      proxy_set_header Host "marketplace.dify.ai";
+      proxy_set_header Connection "";
+    }
+
     location / {
       proxy_pass http://{{ template "dify.web.fullname" .}}:{{ .Values.web.service.port }};
       include proxy.conf;

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -178,6 +178,19 @@ ALIYUN_OSS_AUTH_VERSION: {{ .Values.externalOSS.authVersion }}
 STORAGE_TYPE: google-storage
 GOOGLE_STORAGE_BUCKET_NAME: {{ .Values.externalGCS.bucketName }}
 GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64: {{ .Values.externalGCS.serviceAccountJsonBase64 }}
+{{- else if .Values.externalCOS.enabled }}
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss`, `google-storage` and `tencent-cos`, Default: `local`
+STORAGE_TYPE: tencent-cos
+# The name of the Tencent COS bucket to use for storing files.
+TENCENT_COS_BUCKET_NAME: {{ .Values.externalCOS.bucketName }}
+# The secret key to use for authenticating with the Tencent COS service.
+TENCENT_COS_SECRET_KEY: {{ .Values.externalCOS.secretKey }}
+# The secret id to use for authenticating with the Tencent COS service.
+TENCENT_COS_SECRET_ID: {{ .Values.externalCOS.secretId }}
+# The region of the Tencent COS service.
+TENCENT_COS_REGION: {{ .Values.externalCOS.region }}
+# The scheme of the Tencent COS service.
+TENCENT_COS_SCHEME: {{ .Values.externalCOS.scheme }}
 {{- else }}
 # The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob`, Default: `local`
 STORAGE_TYPE: local
@@ -260,6 +273,16 @@ MILVUS_PORT: {{ .Values.externalMilvus.port | toString | quote }}
 # MILVUS_PASSWORD: {{ .Values.externalMilvus.password | quote }}
 # The milvus tls switch.
 MILVUS_SECURE: {{ .Values.externalMilvus.useTLS | toString | quote }}
+{{- else if .Values.externalTvector.enabled}}
+# tencent vector configurations, only available when VECTOR_STORE is `tencent`
+VECTOR_STORE: tencent 
+TENCENT_VECTOR_DB_URL: {{ .Values.externalTencent.url }}
+TENCENT_VECTOR_DB_API_KEY: {{ .Values.externalTencent.apiKey }}
+TENCENT_VECTOR_DB_TIMEOUT: {{ .Values.externalTencent.timeout | quote }}
+TENCENT_VECTOR_DB_USERNAME: {{ .Values.externalTencent.username }}
+TENCENT_VECTOR_DB_DATABASE: {{ .Values.externalTencent.database }}
+TENCENT_VECTOR_DB_SHARD: {{ .Values.externalTencent.shard | quote }}
+TENCENT_VECTOR_DB_REPLICAS: {{ .Values.externalTencent.replicas | quote }}
 {{- else if .Values.externalPgvector.enabled}}
 # pgvector configurations, only available when VECTOR_STORE is `pgvecto-rs or pgvector`
 VECTOR_STORE: pgvector

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -147,7 +147,7 @@ DB_DATABASE: {{ .Values.postgresql.global.postgresql.auth.database }}
 
 {{- define "dify.storage.config" -}}
 {{- if .Values.externalS3.enabled }}
-# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss` and `google-storage`, Default: `local`
 STORAGE_TYPE: s3
 # The S3 storage configurations, only available when STORAGE_TYPE is `s3`.
 S3_ENDPOINT: {{ .Values.externalS3.endpoint }}
@@ -156,7 +156,7 @@ S3_BUCKET_NAME: {{ .Values.externalS3.bucketName }}
 # S3_SECRET_KEY: {{ .Values.externalS3.secretKey }}
 S3_REGION: {{ .Values.externalS3.region }}
 {{- else if .Values.externalAzureBlobStorage.enabled }}
-# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss` and `google-storage`, Default: `local`
 STORAGE_TYPE: azure-blob
 # The Azure Blob storage configurations, only available when STORAGE_TYPE is `azure-blob`.
 AZURE_BLOB_ACCOUNT_NAME: {{ .Values.externalAzureBlobStorage.account | quote }}
@@ -164,7 +164,7 @@ AZURE_BLOB_ACCOUNT_NAME: {{ .Values.externalAzureBlobStorage.account | quote }}
 AZURE_BLOB_CONTAINER_NAME: {{ .Values.externalAzureBlobStorage.container | quote }}
 AZURE_BLOB_ACCOUNT_URL: {{ .Values.externalAzureBlobStorage.url | quote }}
 {{- else if .Values.externalOSS.enabled }}
-# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss` and `google-storage`, Default: `local`
 STORAGE_TYPE: aliyun-oss
 # The OSS storage configurations, only available when STORAGE_TYPE is `aliyun-oss`.
 ALIYUN_OSS_ENDPOINT: {{ .Values.externalOSS.endpoint }}
@@ -174,7 +174,7 @@ ALIYUN_OSS_BUCKET_NAME: {{ .Values.externalOSS.bucketName }}
 ALIYUN_OSS_REGION: {{ .Values.externalOSS.region }}
 ALIYUN_OSS_AUTH_VERSION: {{ .Values.externalOSS.authVersion }}
 {{- else if .Values.externalGCS.enabled }}
-# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss` and `google-storage`, Default: `local`
 STORAGE_TYPE: google-storage
 GOOGLE_STORAGE_BUCKET_NAME: {{ .Values.externalGCS.bucketName }}
 GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64: {{ .Values.externalGCS.serviceAccountJsonBase64 }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -154,7 +154,7 @@ S3_ENDPOINT: {{ .Values.externalS3.endpoint }}
 S3_BUCKET_NAME: {{ .Values.externalS3.bucketName }}
 # S3_ACCESS_KEY: {{ .Values.externalS3.accessKey }}
 # S3_SECRET_KEY: {{ .Values.externalS3.secretKey }}
-S3_REGION: 'us-east-1'
+S3_REGION: {{ .Values.externalS3.region }}
 {{- else if .Values.externalAzureBlobStorage.enabled }}
 # The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob` and `aliyun-oss`, Default: `local`
 STORAGE_TYPE: azure-blob

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -147,7 +147,7 @@ DB_DATABASE: {{ .Values.postgresql.global.postgresql.auth.database }}
 
 {{- define "dify.storage.config" -}}
 {{- if .Values.externalS3.enabled }}
-# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob` and `aliyun-oss`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
 STORAGE_TYPE: s3
 # The S3 storage configurations, only available when STORAGE_TYPE is `s3`.
 S3_ENDPOINT: {{ .Values.externalS3.endpoint }}
@@ -156,7 +156,7 @@ S3_BUCKET_NAME: {{ .Values.externalS3.bucketName }}
 # S3_SECRET_KEY: {{ .Values.externalS3.secretKey }}
 S3_REGION: {{ .Values.externalS3.region }}
 {{- else if .Values.externalAzureBlobStorage.enabled }}
-# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob` and `aliyun-oss`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
 STORAGE_TYPE: azure-blob
 # The Azure Blob storage configurations, only available when STORAGE_TYPE is `azure-blob`.
 AZURE_BLOB_ACCOUNT_NAME: {{ .Values.externalAzureBlobStorage.account | quote }}
@@ -164,7 +164,7 @@ AZURE_BLOB_ACCOUNT_NAME: {{ .Values.externalAzureBlobStorage.account | quote }}
 AZURE_BLOB_CONTAINER_NAME: {{ .Values.externalAzureBlobStorage.container | quote }}
 AZURE_BLOB_ACCOUNT_URL: {{ .Values.externalAzureBlobStorage.url | quote }}
 {{- else if .Values.externalOSS.enabled }}
-# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob` and `aliyun-oss`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
 STORAGE_TYPE: aliyun-oss
 # The OSS storage configurations, only available when STORAGE_TYPE is `aliyun-oss`.
 ALIYUN_OSS_ENDPOINT: {{ .Values.externalOSS.endpoint }}
@@ -173,6 +173,11 @@ ALIYUN_OSS_BUCKET_NAME: {{ .Values.externalOSS.bucketName }}
 # ALIYUN_OSS_SECRET_KEY: {{ .Values.externalOSS.secretKey }}
 ALIYUN_OSS_REGION: {{ .Values.externalOSS.region }}
 ALIYUN_OSS_AUTH_VERSION: {{ .Values.externalOSS.authVersion }}
+{{- else if .Values.externalGCS.enabled }}
+# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob` and `google-storage`, Default: `local`
+STORAGE_TYPE: google-storage
+GOOGLE_STORAGE_BUCKET_NAME: {{ .Values.externalGCS.bucketName }}
+GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64: {{ .Values.externalGCS.serviceAccountJsonBase64 }}
 {{- else }}
 # The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob`, Default: `local`
 STORAGE_TYPE: local

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -355,7 +355,7 @@ http {
     keepalive_timeout  65;
 
     #gzip  on;
-    client_max_body_size 15M;
+    client_max_body_size {{ .Values.proxy.clientMaxBodySize | default "15m" }};
 
     include /etc/nginx/conf.d/*.conf;
 }

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -14,7 +14,8 @@ CODE_EXECUTION_API_KEY: {{ .Values.sandbox.auth.apiKey | b64enc | quote }}
 {{ include "dify.vectordb.credentials" . }}
 {{ include "dify.mail.credentials" . }}
 {{- if .Values.pluginDaemon.enabled }}
-PLUGIN_DAEMON_KEY: {{ .Values.pluginDaemon.auth.apiKey | b64enc | quote }}
+PLUGIN_DAEMON_KEY: {{ .Values.pluginDaemon.auth.serverKey | b64enc | quote }}
+INNER_API_KEY_FOR_PLUGIN: {{ .Values.pluginDaemon.auth.difyApiKey | b64enc | quote }}
 {{- end }}
 {{- end }}
 
@@ -34,7 +35,8 @@ SECRET_KEY: {{ .Values.api.secretKey | b64enc | quote }}
 {{ include "dify.vectordb.credentials" . }}
 {{ include "dify.mail.credentials" . }}
 {{- if .Values.pluginDaemon.enabled }}
-PLUGIN_DAEMON_KEY: {{ .Values.pluginDaemon.auth.apiKey | b64enc | quote }}
+PLUGIN_DAEMON_KEY: {{ .Values.pluginDaemon.auth.serverKey | b64enc | quote }}
+INNER_API_KEY_FOR_PLUGIN: {{ .Values.pluginDaemon.auth.difyApiKey | b64enc | quote }}
 {{- end }}
 {{- end }}
 
@@ -139,5 +141,6 @@ API_KEY: {{ .Values.sandbox.auth.apiKey | b64enc | quote }}
 {{- define "dify.pluginDaemon.credentials" -}}
 {{ include "dify.db.credentials" . }}
 {{ include "dify.redis.credentials" . }}
-SERVER_KEY: {{ .Values.pluginDaemon.auth.apiKey | b64enc | quote }}
+SERVER_KEY: {{ .Values.pluginDaemon.auth.serverKey | b64enc | quote }}
+DIFY_INNER_API_KEY: {{ .Values.pluginDaemon.auth.difyApiKey | b64enc | quote }}
 {{- end }}

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -13,6 +13,9 @@ CODE_EXECUTION_API_KEY: {{ .Values.sandbox.auth.apiKey | b64enc | quote }}
 {{ include "dify.storage.credentials" . }}
 {{ include "dify.vectordb.credentials" . }}
 {{ include "dify.mail.credentials" . }}
+{{- if .Values.pluginDaemon.enabled }}
+PLUGIN_DAEMON_KEY: {{ .Values.pluginDaemon.auth.apiKey | b64enc | quote }}
+{{- end }}
 {{- end }}
 
 {{- define "dify.worker.credentials" -}}
@@ -30,6 +33,9 @@ SECRET_KEY: {{ .Values.api.secretKey | b64enc | quote }}
 # The Vector store configurations.
 {{ include "dify.vectordb.credentials" . }}
 {{ include "dify.mail.credentials" . }}
+{{- if .Values.pluginDaemon.enabled }}
+PLUGIN_DAEMON_KEY: {{ .Values.pluginDaemon.auth.apiKey | b64enc | quote }}
+{{- end }}
 {{- end }}
 
 {{- define "dify.web.credentials" -}}
@@ -128,4 +134,10 @@ SMTP_PASSWORD: {{ .Values.api.mail.smtp.password | b64enc | quote }}
 
 {{- define "dify.sandbox.credentials" -}}
 API_KEY: {{ .Values.sandbox.auth.apiKey | b64enc | quote }}
+{{- end }}
+
+{{- define "dify.pluginDaemon.credentials" -}}
+{{ include "dify.db.credentials" . }}
+{{ include "dify.redis.credentials" . }}
+SERVER_KEY: {{ .Values.pluginDaemon.auth.apiKey | b64enc | quote }}
 {{- end }}

--- a/charts/dify/templates/plugin-daemon-config.yaml
+++ b/charts/dify/templates/plugin-daemon-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "dify.pluginDaemon.fullname" . }}
+data:
+  {{- include "dify.pluginDaemon.config" . | nindent 2 }}

--- a/charts/dify/templates/plugin-daemon-deployment.yaml
+++ b/charts/dify/templates/plugin-daemon-deployment.yaml
@@ -115,5 +115,5 @@ spec:
       volumes:
       - name: app-data
         persistentVolumeClaim:
-          claimName: {{ .Values.pluginDaemon.persistence.persistentVolumeClaim.existingClaim | default (printf "%s" (include "dify.fullname" . | trunc 58)) }}
+          claimName: {{ .Values.pluginDaemon.persistence.persistentVolumeClaim.existingClaim | default (printf "%s" (include "dify.pluginDaemon.fullname" . | trunc 58)) }}
 {{- end }}

--- a/charts/dify/templates/plugin-daemon-deployment.yaml
+++ b/charts/dify/templates/plugin-daemon-deployment.yaml
@@ -1,0 +1,116 @@
+{{- if and .Values.pluginDaemon.enabled}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+{{ include "dify.ud.annotations" . | indent 4 }}
+    descriptions: plugin-daemon
+  labels:
+{{- include "dify.labels" . | nindent 4 }}
+    component: plugin-daemon
+    # app: {{ template "dify.pluginDaemon.fullname" . }}
+{{ include "dify.ud.labels" . | indent 4 }}
+  name: {{ template "dify.pluginDaemon.fullname" . }}
+spec:
+  replicas: {{ .Values.pluginDaemon.replicas }}
+  selector:
+    matchLabels:
+{{- include "dify.selectorLabels" . | nindent 6 }}
+      component: plugin-daemon
+      {{/*
+      # Required labels for istio
+      # app: {{ template "dify.pluginDaemon.fullname" . }}
+      # version: {{ (print "v" .Values.serviceMesh.version) | quote }}
+      */}}
+  template:
+    metadata:
+      annotations:
+        checksum/plugin-daemon-config: {{ include (print $.Template.BasePath "/plugin-daemon-config.yaml") . | sha256sum }}
+        checksum/plugin-daemon-secret: {{ include (print $.Template.BasePath "/plugin-daemon-secret.yaml") . | sha256sum }}
+{{ include "dify.ud.annotations" . | indent 8 }}
+      labels:
+{{- include "dify.selectorLabels" . | nindent 8 }}
+        component: plugin-daemon
+        {{/*
+        # Required labels for istio
+        # app: {{ template "dify.pluginDaemon.fullname" . }}
+        # version: {{ (print "v" .Values.serviceMesh.version) | quote }}
+        */}}
+{{ include "dify.ud.labels" . | indent 8 }}
+    spec:
+      serviceAccountName: {{ include "dify.pluginDaemon.serviceAccountName" . }}
+      {{- if .Values.image.pluginDaemon.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pluginDaemon.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.pluginDaemon.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.pluginDaemon.podSecurityContext | indent 8 }}
+      {{- end }}
+      containers:
+      - image: "{{ .Values.image.pluginDaemon.repository }}:{{ default .Chart.AppVersion .Values.image.pluginDaemon.tag }}"
+        imagePullPolicy: "{{ .Values.image.pluginDaemon.pullPolicy }}"
+        name: plugin-daemon
+        {{- if .Values.pluginDaemon.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.pluginDaemon.customLivenessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.pluginDaemon.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.pluginDaemon.customReadinessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.pluginDaemon.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.pluginDaemon.customStartupProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.pluginDaemon.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.pluginDaemon.containerSecurityContext | indent 10 }}
+        {{- end }}
+        env:
+        {{- if .Values.pluginDaemon.extraEnv }}
+          {{- toYaml .Values.pluginDaemon.extraEnv | nindent 8 }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ template "dify.pluginDaemon.fullname" . }}
+        - secretRef:
+            name: {{ template "dify.pluginDaemon.fullname" . }}
+        ports:
+          - name: api
+            containerPort: 5002
+            protocol: TCP
+        resources:
+          {{- toYaml .Values.pluginDaemon.resources | nindent 12 }}
+        volumeMounts:
+        - name: app-data
+          mountPath: {{ .Values.pluginDaemon.persistence.mountPath | quote }}
+          subPath: {{ .Values.pluginDaemon.persistence.persistentVolumeClaim.subPath | default "" }}
+    {{- if and (.Values.nodeSelector) (not .Values.pluginDaemon.nodeSelector) }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.pluginDaemon.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.pluginDaemon.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.affinity) (not .Values.pluginDaemon.affinity) }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.pluginDaemon.affinity }}
+      affinity:
+{{ toYaml .Values.pluginDaemon.affinity | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.tolerations) (not .Values.pluginDaemon.tolerations) }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.pluginDaemon.tolerations }}
+      tolerations:
+{{ toYaml .Values.pluginDaemon.tolerations | indent 8 }}
+    {{- end }}
+      volumes:
+      - name: app-data
+        persistentVolumeClaim:
+          claimName: {{ .Values.pluginDaemon.persistence.persistentVolumeClaim.existingClaim | default (printf "%s" (include "dify.fullname" . | trunc 58)) }}
+{{- end }}

--- a/charts/dify/templates/plugin-daemon-deployment.yaml
+++ b/charts/dify/templates/plugin-daemon-deployment.yaml
@@ -76,9 +76,12 @@ spec:
         - secretRef:
             name: {{ template "dify.pluginDaemon.fullname" . }}
         ports:
-          - name: api
-            containerPort: 5002
-            protocol: TCP
+        - name: daemon
+          containerPort: 5002
+          protocol: TCP
+        - name: plugin-install
+          containerPort: 5003
+          protocol: TCP
         resources:
           {{- toYaml .Values.pluginDaemon.resources | nindent 12 }}
         volumeMounts:

--- a/charts/dify/templates/plugin-daemon-secret.yaml
+++ b/charts/dify/templates/plugin-daemon-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "dify.pluginDaemon.fullname" . }}
+type: Opaque
+data:
+  {{- include "dify.pluginDaemon.credentials" . | nindent 2 }}

--- a/charts/dify/templates/plugin-daemon-svc.yaml
+++ b/charts/dify/templates/plugin-daemon-svc.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.pluginDaemon.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "dify.pluginDaemon.fullname" . }}
+  labels:
+{{ include "dify.labels" . | indent 4 }}
+{{- if .Values.pluginDaemon.service.labels }}
+{{ toYaml .Values.pluginDaemon.service.labels | indent 4 }}
+{{- end }}
+    component: "plugin-daemon"
+{{- with .Values.pluginDaemon.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  {{- if .Values.pluginDaemon.service.clusterIP }}
+  clusterIP: {{ .Values.pluginDaemon.service.clusterIP }}
+  {{- end }}
+  ports:
+    - name: http-api
+      port: {{ .Values.pluginDaemon.service.port }}
+      protocol: TCP
+      targetPort: api
+  selector:
+{{ include "dify.selectorLabels" . | indent 4 }}
+    component: "plugin-daemon"
+{{- end }}

--- a/charts/dify/templates/plugin-daemon-svc.yaml
+++ b/charts/dify/templates/plugin-daemon-svc.yaml
@@ -19,10 +19,16 @@ spec:
   clusterIP: {{ .Values.pluginDaemon.service.clusterIP }}
   {{- end }}
   ports:
-    - name: http-api
-      port: {{ .Values.pluginDaemon.service.port }}
-      protocol: TCP
-      targetPort: api
+  - name: http-daemon
+    port: {{ .Values.pluginDaemon.service.ports.daemon }}
+    protocol: TCP
+    targetPort: daemon
+  {{- if .Values.pluginDaemon.service.ports.pluginInstall }}
+  - name: http-plugin-install
+    port: {{ .Values.pluginDaemon.service.ports.pluginInstall }}
+    protocol: TCP
+    targetPort: plugin-install
+    {{- end }}
   selector:
 {{ include "dify.selectorLabels" . | indent 4 }}
     component: "plugin-daemon"

--- a/charts/dify/templates/proxy-deployment.yaml
+++ b/charts/dify/templates/proxy-deployment.yaml
@@ -36,9 +36,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
-      {{- if .Values.proxy.serviceAccountName}}
-      serviceAccountName: {{ .Values.proxy.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "dify.proxy.serviceAccountName" . }}
       {{- if .Values.image.proxy.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.proxy.pullSecrets }}

--- a/charts/dify/templates/proxy-deployment.yaml
+++ b/charts/dify/templates/proxy-deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/proxy-config: {{ include (print $.Template.BasePath "/proxy-configmap.yaml") . | sha256sum }}
 {{ include "dify.ud.annotations" . | indent 8 }}
       labels:
 {{- include "dify.selectorLabels" . | nindent 8 }}

--- a/charts/dify/templates/proxy-deployment.yaml
+++ b/charts/dify/templates/proxy-deployment.yaml
@@ -43,6 +43,10 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.proxy.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.proxy.podSecurityContext | indent 8 }}
+      {{- end }}
       containers:
       - image: "{{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}"
         imagePullPolicy: "{{ .Values.image.proxy.pullPolicy }}"
@@ -55,6 +59,10 @@ spec:
         {{- end }}
         {{- if .Values.proxy.customStartupProbe }}
         startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customStartupProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.proxy.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.proxy.containerSecurityContext | indent 10 }}
         {{- end }}
         env:
         {{- if .Values.proxy.extraEnv }}

--- a/charts/dify/templates/proxy-deployment.yaml
+++ b/charts/dify/templates/proxy-deployment.yaml
@@ -49,6 +49,15 @@ spec:
       - image: "{{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}"
         imagePullPolicy: "{{ .Values.image.proxy.pullPolicy }}"
         name: nginx
+        {{- if .Values.proxy.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customLivenessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.proxy.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customReadinessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.proxy.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customStartupProbe "context" $) | nindent 10 }}
+        {{- end }}
         env:
         {{- if .Values.proxy.extraEnv }}
           {{- toYaml .Values.proxy.extraEnv | nindent 8 }}

--- a/charts/dify/templates/proxy-deployment.yaml
+++ b/charts/dify/templates/proxy-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      {{- if .Values.proxy.serviceAccountName}}
+      serviceAccountName: {{ .Values.proxy.serviceAccountName }}
+      {{- end }}
       {{- if .Values.image.proxy.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.proxy.pullSecrets }}

--- a/charts/dify/templates/proxy-service-account.yaml
+++ b/charts/dify/templates/proxy-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.proxy.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.proxy.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: proxy
+  {{- if or .Values.proxy.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.proxy.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/templates/pvc.yaml
+++ b/charts/dify/templates/pvc.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ printf "%s" (include "dify.fullname" . | trunc 58)}}
+  name: {{ printf "%s" (include "dify.fullname" . | trunc 58) }}
 {{- with .Values.api.persistence.annotations  }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -36,7 +36,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ printf "%s-logs" (include "dify.nginx.fullname" . | trunc 58)}}
+  name: {{ printf "%s-logs" (include "dify.nginx.fullname" . | trunc 58) }}
 {{- with .Values.proxy.log.persistence.annotations  }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -67,8 +67,39 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ printf "%s-logs" (include "dify.ssrfProxy.fullname" . | trunc 58)}}
+  name: {{ printf "%s-logs" (include "dify.ssrfProxy.fullname" . | trunc 58) }}
 {{- with .Values.ssrfProxy.log.persistence.annotations  }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{ include "dify.labels" . | indent 4 }}
+spec:
+  accessModes:
+  - {{ $pvc.accessModes | quote }}
+  {{- if $pvc.storageClass }}
+    {{- if eq "-" $pvc.storageClass }}
+  storageClassName: ""
+    {{- else }}
+  storageClassName: {{ $pvc.storageClass }}
+    {{- end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ $pvc.size }}
+{{- end }}
+
+
+{{- $pvc := .Values.pluginDaemon.persistence.persistentVolumeClaim -}}
+{{- if and .Values.pluginDaemon.enabled (not $pvc.existingClaim) }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ printf "%s" (include "dify.pluginDaemon.fullname" . | trunc 58) }}
+{{- with .Values.pluginDaemon.persistence.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -36,9 +36,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
-      {{- if .Values.sandbox.serviceAccountName}}
-      serviceAccountName: {{ .Values.sandbox.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "dify.sandbox.serviceAccountName" . }}
       {{- if .Values.image.sandbox.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.sandbox.pullSecrets }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -43,6 +43,10 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.sandbox.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.sandbox.podSecurityContext | indent 8 }}
+      {{- end }}
       containers:
       - image: "{{ .Values.image.sandbox.repository }}:{{ .Values.image.sandbox.tag }}"
         imagePullPolicy: "{{ .Values.image.sandbox.pullPolicy }}"
@@ -67,6 +71,10 @@ spec:
         startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.sandbox.startupProbe "enabled") "context" $) | nindent 10 }}
           tcpSocket:
             port: sandbox
+        {{- end }}
+        {{- if .Values.sandbox.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sandbox.containerSecurityContext | indent 10 }}
         {{- end }}
         env:
         {{- if .Values.sandbox.extraEnv }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -25,6 +25,8 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/sandbox-config: {{ include (print $.Template.BasePath "/sandbox-config.yaml") . | sha256sum }}
+        checksum/sandbox-secret: {{ include (print $.Template.BasePath "/sandbox-secret.yaml") . | sha256sum }}
 {{ include "dify.ud.annotations" . | indent 8 }}
       labels:
 {{- include "dify.selectorLabels" . | nindent 8 }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -55,14 +55,16 @@ spec:
         livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.customLivenessProbe "context" $) | nindent 10 }}
         {{- else if .Values.sandbox.livenessProbe.enabled }}
         livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.sandbox.livenessProbe "enabled") "context" $) | nindent 10 }}
-          tcpSocket:
+          httpGet:
+            path: /health
             port: sandbox
         {{- end }}
         {{- if .Values.sandbox.customReadinessProbe }}
         readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.customReadinessProbe "context" $) | nindent 10 }}
         {{- else if .Values.sandbox.readinessProbe.enabled }}
         readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.sandbox.readinessProbe "enabled") "context" $) | nindent 10 }}
-          tcpSocket:
+          httpGet:
+            path: /health
             port: sandbox
         {{- end }}
         {{- if .Values.sandbox.customStartupProbe }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -49,6 +49,27 @@ spec:
       - image: "{{ .Values.image.sandbox.repository }}:{{ .Values.image.sandbox.tag }}"
         imagePullPolicy: "{{ .Values.image.sandbox.pullPolicy }}"
         name: sandbox
+        {{- if .Values.sandbox.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.customLivenessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.sandbox.livenessProbe.enabled }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.sandbox.livenessProbe "enabled") "context" $) | nindent 10 }}
+          tcpSocket:
+            port: sandbox
+        {{- end }}
+        {{- if .Values.sandbox.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.customReadinessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.sandbox.readinessProbe.enabled }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.sandbox.readinessProbe "enabled") "context" $) | nindent 10 }}
+          tcpSocket:
+            port: sandbox
+        {{- end }}
+        {{- if .Values.sandbox.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.customStartupProbe "context" $) | nindent 10 }}
+        {{- else if .Values.sandbox.startupProbe.enabled }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.sandbox.startupProbe "enabled") "context" $) | nindent 10 }}
+          tcpSocket:
+            port: sandbox
+        {{- end }}
         env:
         {{- if .Values.sandbox.extraEnv }}
           {{- toYaml .Values.sandbox.extraEnv | nindent 8 }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      {{- if .Values.sandbox.serviceAccountName}}
+      serviceAccountName: {{ .Values.sandbox.serviceAccountName }}
+      {{- end }}
       {{- if .Values.image.sandbox.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.sandbox.pullSecrets }}

--- a/charts/dify/templates/sandbox-service-account.yaml
+++ b/charts/dify/templates/sandbox-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.sandbox.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.sandbox.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: sandbox
+  {{- if or .Values.sandbox.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.sandbox.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.sandbox.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -36,6 +36,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "dify.ssrfProxy.serviceAccountName" . }}
       {{- if .Values.image.ssrfProxy.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.ssrfProxy.pullSecrets }}

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/ssrf-proxy-config: {{ include (print $.Template.BasePath "/ssrf-proxy-configmap.yaml") . | sha256sum }}
 {{ include "dify.ud.annotations" . | indent 8 }}
       labels:
 {{- include "dify.selectorLabels" . | nindent 8 }}

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -43,6 +43,10 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.ssrfProxy.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.ssrfProxy.podSecurityContext | indent 8 }}
+      {{- end }}
       containers:
       - image: "{{ .Values.image.ssrfProxy.repository }}:{{ .Values.image.ssrfProxy.tag }}"
         imagePullPolicy: "{{ .Values.image.ssrfProxy.pullPolicy }}"
@@ -55,6 +59,10 @@ spec:
         {{- end }}
         {{- if .Values.ssrfProxy.customStartupProbe }}
         startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.customStartupProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.ssrfProxy.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.ssrfProxy.containerSecurityContext | indent 10 }}
         {{- end }}
         env:
         {{- if .Values.ssrfProxy.extraEnv }}

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -46,6 +46,15 @@ spec:
       - image: "{{ .Values.image.ssrfProxy.repository }}:{{ .Values.image.ssrfProxy.tag }}"
         imagePullPolicy: "{{ .Values.image.ssrfProxy.pullPolicy }}"
         name: squid
+        {{- if .Values.ssrfProxy.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.customLivenessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.ssrfProxy.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.customReadinessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.ssrfProxy.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.customStartupProbe "context" $) | nindent 10 }}
+        {{- end }}
         env:
         {{- if .Values.ssrfProxy.extraEnv }}
           {{- toYaml .Values.ssrfProxy.extraEnv | nindent 8 }}

--- a/charts/dify/templates/ssrf-proxy-service-account.yaml
+++ b/charts/dify/templates/ssrf-proxy-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.ssrfProxy.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.ssrfProxy.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: ssrfProxy
+  {{- if or .Values.ssrfProxy.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ssrfProxy.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.ssrfProxy.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/templates/validations/_tplvalues.tpl
+++ b/charts/dify/templates/validations/_tplvalues.tpl
@@ -1,0 +1,52 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template perhaps with scope if the scope is present.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Merge a list of values that contains template after rendering them.
+Merge precedence is consistent with http://masterminds.github.io/sprig/dicts.html#merge-mustmerge
+Usage:
+{{ include "common.tplvalues.merge" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+*/}}
+{{- define "common.tplvalues.merge" -}}
+{{- $dst := dict -}}
+{{- range .values -}}
+{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | merge $dst -}}
+{{- end -}}
+{{ $dst | toYaml }}
+{{- end -}}
+
+{{/*
+Merge a list of values that contains template after rendering them.
+Merge precedence is consistent with https://masterminds.github.io/sprig/dicts.html#mergeoverwrite-mustmergeoverwrite
+Usage:
+{{ include "common.tplvalues.merge-overwrite" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+*/}}
+{{- define "common.tplvalues.merge-overwrite" -}}
+{{- $dst := dict -}}
+{{- range .values -}}
+{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | mergeOverwrite $dst -}}
+{{- end -}}
+{{ $dst | toYaml }}
+{{- end -}}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -36,9 +36,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
-      {{- if .Values.web.serviceAccountName}}
-      serviceAccountName: {{ .Values.web.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "dify.web.serviceAccountName" . }}
       {{- if .Values.image.web.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.web.pullSecrets }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -86,6 +86,10 @@ spec:
 {{ toYaml .Values.web.containerSecurityContext | indent 10 }}
         {{- end }}
         env:
+        - name: MARKETPLACE_URL
+          value: https://marketplace.dify.ai
+        - name: MARKETPLACE_API_URL
+          value: /marketplace
         {{- if .Values.web.extraEnv }}
           {{- toYaml .Values.web.extraEnv | nindent 8 }}
         {{- end }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-      - image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag }}"
+      - image: "{{ .Values.image.web.repository }}:{{ default .Chart.AppVersion .Values.image.web.tag }}"
         imagePullPolicy: "{{ .Values.image.web.pullPolicy }}"
         name: web
         {{- if .Values.web.customLivenessProbe }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/web-config: {{ include (print $.Template.BasePath "/web-config.yaml") . | sha256sum }}
 {{ include "dify.ud.annotations" . | indent 8 }}
       labels:
 {{- include "dify.selectorLabels" . | nindent 8 }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -43,6 +43,10 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.web.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.web.podSecurityContext | indent 8 }}
+      {{- end }}
       containers:
       - image: "{{ .Values.image.web.repository }}:{{ default .Chart.AppVersion .Values.image.web.tag }}"
         imagePullPolicy: "{{ .Values.image.web.pullPolicy }}"
@@ -75,6 +79,10 @@ spec:
         startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.startupProbe "enabled") "context" $) | nindent 10 }}
           tcpSocket:
             port: web
+        {{- end }}
+        {{- if .Values.web.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.web.containerSecurityContext | indent 10 }}
         {{- end }}
         env:
         {{- if .Values.web.extraEnv }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      {{- if .Values.web.serviceAccountName}}
+      serviceAccountName: {{ .Values.web.serviceAccountName }}
+      {{- end }}
       {{- if .Values.image.web.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.web.pullSecrets }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.livenessProbe "enabled") "context" $) | nindent 10 }}
           httpGet:
             path: /apps
-            port: http
+            port: web
             httpHeaders:
             - name: accept-language
               value: en
@@ -66,7 +66,7 @@ spec:
         readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.readinessProbe "enabled") "context" $) | nindent 10 }}
           httpGet:
             path: /apps
-            port: http
+            port: web
             httpHeaders:
             - name: accept-language
               value: en

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -49,6 +49,35 @@ spec:
       - image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag }}"
         imagePullPolicy: "{{ .Values.image.web.pullPolicy }}"
         name: web
+        {{- if .Values.web.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.web.customLivenessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.web.livenessProbe.enabled }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.livenessProbe "enabled") "context" $) | nindent 10 }}
+          httpGet:
+            path: /apps
+            port: http
+            httpHeaders:
+            - name: accept-language
+              value: en
+        {{- end }}
+        {{- if .Values.web.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.web.customReadinessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.web.readinessProbe.enabled }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.readinessProbe "enabled") "context" $) | nindent 10 }}
+          httpGet:
+            path: /apps
+            port: http
+            httpHeaders:
+            - name: accept-language
+              value: en
+        {{- end }}
+        {{- if .Values.web.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.web.customStartupProbe "context" $) | nindent 10 }}
+        {{- else if .Values.web.startupProbe.enabled }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.startupProbe "enabled") "context" $) | nindent 10 }}
+          tcpSocket:
+            port: web
+        {{- end }}
         env:
         {{- if .Values.web.extraEnv }}
           {{- toYaml .Values.web.extraEnv | nindent 8 }}

--- a/charts/dify/templates/web-service-account.yaml
+++ b/charts/dify/templates/web-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.web.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.web.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: web
+  {{- if or .Values.web.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.web.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.web.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -37,9 +37,7 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
-      {{- if .Values.worker.serviceAccountName}}
-      serviceAccountName: {{ .Values.worker.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "dify.worker.serviceAccountName" . }}
       {{- if .Values.image.api.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.api.pullSecrets }}

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.worker.enabled}}
-{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled) -}}
+{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -44,6 +44,10 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.worker.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.worker.podSecurityContext | indent 8 }}
+      {{- end }}
       containers:
       - image: "{{ .Values.image.api.repository }}:{{ default .Chart.AppVersion .Values.image.api.tag }}"
         imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"
@@ -56,6 +60,10 @@ spec:
         {{- end }}
         {{- if .Values.worker.customStartupProbe }}
         startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customStartupProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.worker.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.worker.containerSecurityContext | indent 10 }}
         {{- end }}
         env:
         {{- if .Values.worker.extraEnv }}

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.worker.enabled}}
-{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled) -}}
+{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalOSS.enabled .Values.externalAzureBlobStorage.enabled .Values.externalGCS.enabled .Values.externalCOS.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-      - image: "{{ .Values.image.api.repository }}:{{ .Values.image.api.tag }}"
+      - image: "{{ .Values.image.api.repository }}:{{ default .Chart.AppVersion .Values.image.api.tag }}"
         imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"
         name: worker
         {{- if .Values.worker.customLivenessProbe }}

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -26,6 +26,8 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/worker-config: {{ include (print $.Template.BasePath "/worker-config.yaml") . | sha256sum }}
+        checksum/worker-secret: {{ include (print $.Template.BasePath "/worker-secret.yaml") . | sha256sum }}
 {{ include "dify.ud.annotations" . | indent 8 }}
       labels:
 {{- include "dify.selectorLabels" . | nindent 8 }}

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -50,6 +50,15 @@ spec:
       - image: "{{ .Values.image.api.repository }}:{{ .Values.image.api.tag }}"
         imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"
         name: worker
+        {{- if .Values.worker.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customLivenessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.worker.customReadinessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customReadinessProbe "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.worker.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customStartupProbe "context" $) | nindent 10 }}
+        {{- end }}
         env:
         {{- if .Values.worker.extraEnv }}
           {{- toYaml .Values.worker.extraEnv | nindent 8 }}

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         */}}
 {{ include "dify.ud.labels" . | indent 8 }}
     spec:
+      {{- if .Values.worker.serviceAccountName}}
+      serviceAccountName: {{ .Values.worker.serviceAccountName }}
+      {{- end }}
       {{- if .Values.image.api.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.api.pullSecrets }}

--- a/charts/dify/templates/worker-service-account.yaml
+++ b/charts/dify/templates/worker-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.worker.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.worker.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: worker
+  {{- if or .Values.worker.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.worker.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.worker.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -194,7 +194,22 @@ api:
       accessModes: ReadWriteMany
       size: 5Gi
       subPath: ""
-
+  ## Dify API ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param api.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param api.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param api.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param api.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
 worker:
   enabled: true
@@ -225,6 +240,22 @@ worker:
   #        name: my-secret
   #        key: DB_PASSWORD
   logLevel: INFO
+  ## Dify Worker ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param worker.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param worker.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param worker.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param worker.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
 proxy:
   enabled: true
@@ -274,6 +305,22 @@ proxy:
     annotations: {}
     labels: {}
     clusterIP: ""
+  ## Proxy ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param proxy.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param proxy.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param proxy.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param proxy.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
 web:
   enabled: true
@@ -323,6 +370,22 @@ web:
     annotations: {}
     labels: {}
     clusterIP: ""
+  ## Web ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param web.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param web.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param web.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param web.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
 sandbox:
   enabled: true
@@ -378,6 +441,22 @@ sandbox:
     apiKey: "dify-sandbox"
   privileged:
     false
+  ## Sandbox ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param sandbox.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param sandbox.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param sandbox.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param sandbox.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
 ssrfProxy:
   enabled: false
@@ -425,6 +504,22 @@ ssrfProxy:
     annotations: {}
     labels: {}
     clusterIP: ""
+  ## ssrfProxy ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param ssrfProxy.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param ssrfProxy.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param ssrfProxy.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param ssrfProxy.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: { }
 
 postgresql:
   enabled: true

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -5,7 +5,7 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "0.6.16"
+    tag: "0.14.2"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -15,7 +15,7 @@ image:
     #   - myRegistryKeySecretName
   web:    
     repository: langgenius/dify-web
-    tag: "0.6.16"
+    tag: "0.14.2"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -25,7 +25,7 @@ image:
     #   - myRegistryKeySecretName
   sandbox:
     repository: langgenius/dify-sandbox
-    tag: "0.2.1"
+    tag: "0.2.10"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -13,7 +13,7 @@ image:
     ##
     # pullSecrets:
     #   - myRegistryKeySecretName
-  web:    
+  web:
     repository: langgenius/dify-web
     tag: "0.14.2"
     pullPolicy: IfNotPresent
@@ -543,7 +543,7 @@ ssrfProxy:
     automountServiceAccountToken: false
     ## @param ssrfProxy.serviceAccount.annotations Additional custom annotations for the ServiceAccount
     ##
-    annotations: { }
+    annotations: {}
 
 postgresql:
   enabled: true
@@ -645,15 +645,15 @@ weaviate:
     - 'http'
     - '--config-file'
     - '/weaviate-config/conf.yaml'
-    - --read-timeout=60s 
+    - --read-timeout=60s
     - --write-timeout=60s
 
   # below is an example that can be used to set an arbitrary nofile limit at
   # startup:
   #
-  # command: 
+  # command:
   #   - "/bin/sh"
-  # args: 
+  # args:
   #   - "-c"
   #   - "ulimit -n 65535 && /bin/weaviate --host 0.0.0.0 --port 8080 --scheme http --config-file /weaviate-config/conf.yaml"
 
@@ -673,7 +673,7 @@ weaviate:
         repo: alpine
         tag: latest
         pullPolicy: IfNotPresent
-    
+
     extraInitContainers: {}
     # - image: some-image
     #   name: some-name
@@ -809,7 +809,7 @@ weaviate:
     # Expose metrics on port 2112 for Prometheus to scrape
     PROMETHEUS_MONITORING_ENABLED: false
 
-    # Set a MEM limit for the Weaviate Pod so it can help you both increase GC-related 
+    # Set a MEM limit for the Weaviate Pod so it can help you both increase GC-related
     # performance as well as avoid GC-related out-of-memory (“OOM”) situations
     # GOMEMLIMIT: 6GiB
 
@@ -861,13 +861,13 @@ weaviate:
       envconfig:
         # Configure folder where backups should be saved
         BACKUP_FILESYSTEM_PATH: /tmp/backups
-    
+
     s3:
       enabled: false
       # If one is using AWS EKS and has already configured K8s Service Account
       # that holds the AWS credentials one can pass a name of that service account
       # here using this setting.
-      # NOTE: the root `serviceAccountName` config has priority over this one, and 
+      # NOTE: the root `serviceAccountName` config has priority over this one, and
       # if the root one is set this one will NOT overwrite it. This one is here for
       # backwards compatibility.
       serviceAccountName:
@@ -876,17 +876,17 @@ weaviate:
         # Configure bucket where backups should be saved, this setting is mandatory
         BACKUP_S3_BUCKET: weaviate-backups
 
-        # Optional setting. Defaults to empty string. 
+        # Optional setting. Defaults to empty string.
         # Set this option if you want to save backups to a given location
         # inside the bucket
         # BACKUP_S3_PATH: path/inside/bucket
 
-        # Optional setting. Defaults to AWS S3 (s3.amazonaws.com). 
+        # Optional setting. Defaults to AWS S3 (s3.amazonaws.com).
         # Set this option if you have a MinIO storage configured in your environment
         # and want to use it instead of the AWS S3.
         # BACKUP_S3_ENDPOINT: custom.minio.endpoint.address
 
-        # Optional setting. Defaults to true. 
+        # Optional setting. Defaults to true.
         # Set this option if you don't want to use SSL.
         # BACKUP_S3_USE_SSL: true
 
@@ -899,7 +899,7 @@ weaviate:
       # You can pass the User credentials (access-key id and access-secret-key) in 2 ways:
       # 1. by setting the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY plain values in the `secrets` section below
       #     this chart will create a kubernetes secret for you with these key-values pairs
-      # 2. create Kubernetes secret/s with AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY  keys and their respective values 
+      # 2. create Kubernetes secret/s with AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY  keys and their respective values
       #     Set the Key and the secret where it is set in `envSecrets` section below
       secrets: {}
       #   AWS_ACCESS_KEY_ID: access-key-id (plain text)
@@ -947,7 +947,7 @@ weaviate:
         # Configure container where backups should be saved, this setting is mandatory
         BACKUP_AZURE_CONTAINER: weaviate-backups
 
-        # Optional setting. Defaults to empty string. 
+        # Optional setting. Defaults to empty string.
         # Set this option if you want to save backups to a given location
         # inside the container
         # BACKUP_AZURE_PATH: path/inside/container
@@ -958,7 +958,7 @@ weaviate:
       # 1. by setting the AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY
       #     or AZURE_STORAGE_CONNECTION_STRING plain values in the `secrets` section below
       #     this chart will create a kubernetes secret for you with these key-values pairs
-      # 2. create Kubernetes secret/s with AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY 
+      # 2. create Kubernetes secret/s with AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY
       #     or AZURE_STORAGE_CONNECTION_STRING and their respective values
       #     Set the Key and the secret where it is set in `envSecrets` section below
       secrets: {}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -2966,13 +2966,13 @@ externalPgvector:
   dbName: dify
 
 ###################################
-# External Tencent
-# - these configs take effect only if both `externalWeaviate.enabled`, `externalQdrant.enabled` and `externalMilvus.enabled` and `externalPgvector.enabled` are set as `false` and `externalTvector.enabled` is `true`
+# External Tencent Vector DB
+# - these configs take effect only if both `externalWeaviate.enabled`, `externalQdrant.enabled` and `externalMilvus.enabled` and `externalPgvector.enabled` are set as `false` and `externalTencentVectorDB.enabled` is `true`
 ###################################
-externalTvector:
+externalTencentVectorDB:
   enabled: false
   url: "your-tencent-vector-db-url"
-  apiKey: "your-tencent-vector-api-key"
+  apiKey: "your-tencent-vector-db-api-key"
   timeout: 30
   username: "root"
   database: "dify"

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -5,7 +5,7 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "0.14.2"
+    tag: "1.0.0"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -15,7 +15,7 @@ image:
     #   - myRegistryKeySecretName
   web:
     repository: langgenius/dify-web
-    tag: "0.14.2"
+    tag: "1.0.0"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -47,6 +47,17 @@ image:
   ssrfProxy:
     repository: ubuntu/squid
     tag: latest
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  pluginDaemon:
+    repository: langgenius/dify-plugin-daemon
+    tag: 0.0.1-local
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -542,6 +553,71 @@ ssrfProxy:
     ##
     automountServiceAccountToken: false
     ## @param ssrfProxy.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
+
+pluginDaemon:
+  enabled: true
+  replicas: 1
+  resources: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  ## Configure extra options for plugin daemon containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param pluginDaemon.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param pluginDaemon.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param pluginDaemon.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
+  # Configure Pods Security Context
+  podSecurityContext: {}
+  # Configure Container Security Context
+  containerSecurityContext: {}
+  extraEnv:
+  # Apply your own Environment Variables if necessary
+  # - name: LANG
+  #   value: "C.UTF-8"
+  service:
+    port: 5002
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+  auth:
+    apiKey: "lYkiYYT6owG+71oLerGzA7GXCgOT++6ovaezWAjpCjf+Sjc3ZtU+qUEi"
+  database: "dify_plugin"
+  persistence:
+    mountPath: "/app/storage/cwd"
+    annotations:
+      helm.sh/resource-policy: keep
+    persistentVolumeClaim:
+      existingClaim: ""
+      ## Dify Plugin Daemon Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.
+      ## ReadWriteMany access mode required for `pluginDaemon`
+      ##
+      storageClass:
+      accessModes: ReadWriteMany
+      size: 5Gi
+      subPath: ""
+  ## pluginDaemon ServiceAccount configuration
+  ##
+  serviceAccount:
+    ## @param pluginDaemon.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## @param pluginDaemon.serviceAccount.name The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the common.names.fullname template
+    ##
+    name: ""
+    ## @param pluginDaemon.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ##
+    automountServiceAccountToken: false
+    ## @param pluginDaemon.serviceAccount.annotations Additional custom annotations for the ServiceAccount
     ##
     annotations: {}
 

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -94,6 +94,10 @@ api:
   customReadinessProbe: {}
   ## @param api.customStartupProbe Custom startupProbe that overrides the default one
   customStartupProbe: {}
+  # Configure Pods Security Context
+  podSecurityContext: {}
+  # Configure Container Security Context
+  containerSecurityContext: {}
   extraEnv:
   # Apply your own Environment Variables if necessary.
   # Variable defined here takes higher priority than those from `ConfigMap` generated given `.Values`
@@ -226,6 +230,10 @@ worker:
   customReadinessProbe: {}
   ## @param worker.customStartupProbe Custom startupProbe that overrides the default one
   customStartupProbe: {}
+  # Configure Pods Security Context
+  podSecurityContext: {}
+  # Configure Container Security Context
+  containerSecurityContext: {}
   extraEnv:
   # Apply your own Environment Variables if necessary.
   # Variable defined here takes higher priority than those from `ConfigMap` generated given `.Values`
@@ -274,6 +282,10 @@ proxy:
   customStartupProbe: {}
   ## @param proxy.clientMaxBodySize Custom client_max_body_size param nginx default: 15m
   clientMaxBodySize: ""
+  # Configure Pods Security Context
+  podSecurityContext: {}
+  # Configure Container Security Context
+  containerSecurityContext: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   # - name: LANG
@@ -361,6 +373,10 @@ web:
   customReadinessProbe: {}
   ## @param web.customStartupProbe Custom startupProbe that overrides the default one
   customStartupProbe: {}
+  # Configure Pods Security Context
+  podSecurityContext: {}
+  # Configure Container Security Context
+  containerSecurityContext: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   - name: EDITION
@@ -426,6 +442,10 @@ sandbox:
   customReadinessProbe: {}
   ## @param sandbox.customStartupProbe Custom startupProbe that overrides the default one
   customStartupProbe: {}
+  # Configure Pods Security Context
+  podSecurityContext: {}
+  # Configure Container Security Context
+  containerSecurityContext: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   # - name: LANG
@@ -473,6 +493,10 @@ ssrfProxy:
   customReadinessProbe: {}
   ## @param ssrfProxy.customStartupProbe Custom startupProbe that overrides the default one
   customStartupProbe: {}
+  # Configure Pods Security Context
+  podSecurityContext: {}
+  # Configure Container Security Context
+  containerSecurityContext: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   # - name: LANG

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -592,7 +592,6 @@ pluginDaemon:
     serverKey: "lYkiYYT6owG+71oLerGzA7GXCgOT++6ovaezWAjpCjf+Sjc3ZtU+qUEi"
     # A separate key for interactions between `api`(`worker`) and `pluginDaemon`
     difyApiKey: "QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1"
-  database: "dify_plugin"
   persistence:
     mountPath: "/app/storage/cwd"
     annotations:
@@ -2948,7 +2947,9 @@ externalPostgres:
   password: "difyai123456"
   address: localhost
   port: 5432
-  dbName: dify
+  database:
+    api: "dify"
+    pluginDaemon: "dify_plugin"
   maxOpenConns: 20
   maxIdleConns: 5
 

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -2801,6 +2801,18 @@ externalGCS:
   serviceAccountJsonBase64: ""
 
 ###################################
+# External TENCENT COS
+# - these configs are only used when `externalS3.enabled` and `externalAzureBlobStorage.enabled` and `externalOSS.enabled`  and `externalGCS.enabled` are false and `externalCOS.enabled` is true
+###################################
+externalCOS:
+  enabled: false
+  secretKey: "your-secret-key"
+  secretId: "your-secret-id"
+  region: "your-region"
+  bucketName: "your-bucket-name"
+  scheme: "your-scheme"
+
+###################################
 # External Redis
 # - these configs are only used when `externalRedis.enabled` is true
 ###################################
@@ -2857,3 +2869,17 @@ externalPgvector:
   address: "pgvector"
   port: 5432
   dbName: dify
+
+###################################
+# External Tencent
+# - these configs take effect only if both `externalWeaviate.enabled`, `externalQdrant.enabled` and `externalMilvus.enabled` and `externalPgvector.enabled` are set as `false` and `externalTvector.enabled` is `true`
+###################################
+externalTvector:
+  enabled: false
+  url: "your-tencent-vector-db-url"
+  apiKey: "your-tencent-vector-api-key"
+  timeout: 30
+  username: "root"
+  database: "dify"
+  shard: 1
+  replicas: 2

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -580,12 +580,18 @@ pluginDaemon:
   # - name: LANG
   #   value: "C.UTF-8"
   service:
-    port: 5002
+    ports:
+      daemon: 5002
+      # Leave it unspecified in order NOT to expose port for remote installation as a `Service`.
+      pluginInstall:
+      # pluginInstall: 5003
     annotations: {}
     labels: {}
     clusterIP: ""
   auth:
-    apiKey: "lYkiYYT6owG+71oLerGzA7GXCgOT++6ovaezWAjpCjf+Sjc3ZtU+qUEi"
+    serverKey: "lYkiYYT6owG+71oLerGzA7GXCgOT++6ovaezWAjpCjf+Sjc3ZtU+qUEi"
+    # A separate key for interactions between `api`(`worker`) and `pluginDaemon`
+    difyApiKey: "QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1"
   database: "dify_plugin"
   persistence:
     mountPath: "/app/storage/cwd"

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -57,7 +57,7 @@ image:
 
   pluginDaemon:
     repository: langgenius/dify-plugin-daemon
-    tag: 0.0.1-local
+    tag: 0.0.3-local
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -3049,6 +3049,7 @@ externalMilvus:
   enabled: false
   host: "your-milvus.domain"
   port: 19530
+  database: 'default'
   user: "user"
   password: "Milvus"
   useTLS: false

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -62,6 +62,38 @@ api:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for api containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param api.livenessProbe.enabled Enable livenessProbe on api nodes
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param api.readinessProbe.enabled Enable readinessProbe on api nodes
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param api.startupProbe.enabled Enable startupProbe on api containers
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param api.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param api.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param api.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary.
   # Variable defined here takes higher priority than those from `ConfigMap` generated given `.Values`
@@ -171,6 +203,14 @@ worker:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for worker containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param worker.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param worker.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param worker.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary.
   # Variable defined here takes higher priority than those from `ConfigMap` generated given `.Values`
@@ -193,6 +233,14 @@ proxy:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for proxy containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param proxy.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param proxy.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param proxy.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   # - name: LANG
@@ -232,6 +280,38 @@ web:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for web containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param web.livenessProbe.enabled Enable livenessProbe on web nodes
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param web.readinessProbe.enabled Enable readinessProbe on web nodes
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param web.startupProbe.enabled Enable startupProbe on web containers
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  ## @param web.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param web.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param web.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   - name: EDITION
@@ -249,6 +329,38 @@ sandbox:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for sandbox containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param sandbox.livenessProbe.enabled Enable livenessProbe on sandbox nodes
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 2
+    successThreshold: 1
+  ## @param sandbox.readinessProbe.enabled Enable readinessProbe on sandbox nodes
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 2
+    successThreshold: 1
+  ## @param sandbox.startupProbe.enabled Enable startupProbe on sandbox containers
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 2
+    successThreshold: 1
+  ## @param sandbox.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param sandbox.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param sandbox.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   # - name: LANG
@@ -272,6 +384,14 @@ ssrfProxy:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Configure extra options for ssrf proxy containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param ssrfProxy.customLivenessProbe Custom livenessProbe that overrides the default one
+  customLivenessProbe: {}
+  ## @param ssrfProxy.customReadinessProbe Custom readinessProbe that overrides the default one
+  customReadinessProbe: {}
+  ## @param ssrfProxy.customStartupProbe Custom startupProbe that overrides the default one
+  customStartupProbe: {}
   extraEnv:
   # Apply your own Environment Variables if necessary
   # - name: LANG

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -241,6 +241,8 @@ proxy:
   customReadinessProbe: {}
   ## @param proxy.customStartupProbe Custom startupProbe that overrides the default one
   customStartupProbe: {}
+  ## @param proxy.clientMaxBodySize Custom client_max_body_size param nginx default: 15m
+  clientMaxBodySize: ""
   extraEnv:
   # Apply your own Environment Variables if necessary
   # - name: LANG

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -2765,6 +2765,7 @@ externalS3:
   rootPath: ""
   useIAM: false
   iamEndpoint: ""
+  region: "us-east-1"
 
 ###################################
 # External Azure Blob Storage

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -2792,6 +2792,15 @@ externalOSS:
   authVersion: v4
 
 ###################################
+# External Google Cloud Storage
+# - these configs are only used when `externalS3.enabled` and `externalAzureBlobStorage.enabled` and `externalOSS.enabled` are false and `externalGCS.enabled` is true
+###################################
+externalGCS:
+  enabled: false
+  bucketName: "difyai"
+  serviceAccountJsonBase64: ""
+
+###################################
 # External Redis
 # - these configs are only used when `externalRedis.enabled` is true
 ###################################

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -5,7 +5,7 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "0.6.11"
+    tag: "0.6.16"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -15,7 +15,7 @@ image:
     #   - myRegistryKeySecretName
   web:    
     repository: langgenius/dify-web
-    tag: "0.6.11"
+    tag: "0.6.16"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,9 @@
+chart-dirs:
+  - charts
+
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
+  - weaviate=https://weaviate.github.io/weaviate-helm
+
+check-version-increment: false
+validate-maintainers: false


### PR DESCRIPTION
Integrating latest changes from [BorisPolonsky/dify-helm](https://github.com/BorisPolonsky/dify-helm) tag dify-0.23.0-rc3

8540a1be1daf879609fcc9dc230c3c06fa7fb44b Bump chart version to 0.23.0-rc3 (BorisPolonsky/dify-helm#143)
c2ac44c317b7f6b14c60bf727881250c683972dd Fix `PersistentVolumeClaim` binding for `pluginDaemon` (BorisPolonsky/dify-helm#141)
7bd1ef22075e0c5511a1569a43eee2b9e53ff8a5 Refactor `extenal.externalPostgres.dbName` as `extenal.externalPostgres.database.api` and `extenal.externalPostgres.database.api.pluginDaemon` (BorisPolonsky/dify-helm#139)
9b55105210d35d72b14d4b4e58826ed85e55cac7 feat: let nginx proxy marketplace api request (BorisPolonsky/dify-helm#131)
4b3170cd4bce1167ba454e169d1cc4af076e1297 Bump version to `0.23.0-rc2` (BorisPolonsky/dify-helm#133)
cf5f10cacce64ca80747ee6f76361d4dbc23bfef Patch plugin startup and add optional service exposure (BorisPolonsky/dify-helm#132)
1ced744a0d352f09cd218e687d06492f90c3e736 Update release.yml (BorisPolonsky/dify-helm#129)
082d10d1008df7a2efb74ee9df6b1d9ce499b542 Update release.yml (BorisPolonsky/dify-helm#128)
c792be3a2a56d17913ac958ab8de33eb5a9d8996 Update chart-releaser (BorisPolonsky/dify-helm#127)
6b162b0150910982dab7750b96e838c0356dee34 Bump chart version to `0.23.0-rc1` and app version to `1.0.0` (BorisPolonsky/dify-helm#124)
140b225c78d72f8036c05bf80e2ae9cd02c423aa Bump image tags to dify-v1.0.0 (BorisPolonsky/dify-helm#126)
ccad36474dde101d0710db548db83bc779a91f24 add external milvus database option (BorisPolonsky/dify-helm#125)
4b44864ffbe40a49d74534c8d492f15c28af1ee8 Add plugin daemon (BorisPolonsky/dify-helm#123)
20283dd6ef28890b9e06512ff9ebfd8c520e41bd Add configmap and secret hash as annotation in `api`, `worker`, `web`, `proxy`, `ssrfProxy` (BorisPolonsky/dify-helm#121)
fe2036d2a5c5be26e7b2b16d355fac2dabf63751 Substitute /healthz api for tcpSocket as default health check logic for `sandbox` (BorisPolonsky/dify-helm#117)
1b3e4a72c5755f6bfc51468535e4a3e1adcf4bd2 Fix lint error (BorisPolonsky/dify-helm#120)
c4224043706f31edfe2501d8a660789b2fb60163 Disable version check for PR (BorisPolonsky/dify-helm#119)
a1cbb44be8ce2d6af55745fc6a2d814a63795388 Add repo info for lint-test (BorisPolonsky/dify-helm#118)
11049515d1367efa371f1973e4118c5a2070c1b3 Add chart testing action (BorisPolonsky/dify-helm#116)
e734227e08847df3f2037db9cf7e2b7e44d2166e Add Chart.lock (BorisPolonsky/dify-helm#115)
539467f5b92d7b3ff054cd2d0e3261e9bc5b2035 Added option to specify security context (BorisPolonsky/dify-helm#113)
3398dab7462b509be1f550628b0175f50ae82d1b Apply `.Chart.AppVersion` as `tag` for `api`, `worker` and `web` if left empty (BorisPolonsky/dify-helm#105)
5a67aff25c9b9c24396a98d26378472e6277405a Update app version to `0.14.2` and bump chart version to `0.22.0` (BorisPolonsky/dify-helm#109)
48108739525b7f02df589ca14891f6a6caf2bf6e Update README.md (BorisPolonsky/dify-helm#108)
2df3710e6fdeaaa3920c05e8c5e26e01822e0124 Patch Tencent Vector DB Confiuration (BorisPolonsky/dify-helm#106)
ca5aa52febe692f0d9b0a888560c54a47379fe0b feat: add service account for each services (BorisPolonsky/dify-helm#99)
4fc4e08823f23b2cb2bcf2f9076dc90d537bfb82 add Tencent-vectorDB and tencent-cos (BorisPolonsky/dify-helm#104)
0d534465fa28418dea6ef01ec7d21a3427feeacf Patch comments of external storages introduced in `4544ebd788f6a0c56c968b9854552a43c3e42277` (BorisPolonsky/dify-helm#103)
4544ebd788f6a0c56c968b9854552a43c3e42277 feat: add external google cloud storage config (BorisPolonsky/dify-helm#100)
0e59632ed48e74d147ab32c092b7e31d0ec30b0e Move default value of `S3_REGION` to `.Values.externalS3.region` (BorisPolonsky/dify-helm#102)
fdccbfc1ebcb4d4ad169ab2b2a0f7f63dc6293ad Add a flexible set of clientMaxBodySize limits (BorisPolonsky/dify-helm#97)
0117f962ca125156b0e4b4d39dfb6e9b7abd5b2f Fix default definition of `readinesProbe` and `livenessProbe` (BorisPolonsky/dify-helm#96)
6e44ca4d03fb2fe984b6e580b3c1c669c6fcae8a `livenessProbe`, `readinessProbe` and `startupProbe` support (BorisPolonsky/dify-helm#94)
199785cd6678a6dd03a8e8dd8d15d73c7af52142 add service account to deployments (BorisPolonsky/dify-helm#92)
6ae42f34836a641b1ee34ad591143a709227e8d7 Update to 0.21.0 (BorisPolonsky/dify-helm#87)